### PR TITLE
Don't rely on state to be updated synchronously.

### DIFF
--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -186,25 +186,23 @@ var HeaderControls = React.createClass({
   getNext() {
     var next = this.state.selectedMonth + 1;
     if (next > 11) {
-      this.setState({ selectedMonth: 0 });
-      this.props.getNextYear();
-    } else {
-      this.setState({ selectedMonth: next });
+      next = 0
+      this.props.getNextYear(next);
     }
 
-    this.props.onMonthChange(this.state.selectedMonth);
+    this.setState({ selectedMonth: next });
+    this.props.onMonthChange(next);
   },
 
   getPrevious() {
     var prev = this.state.selectedMonth - 1;
     if (prev < 0) {
-      this.setState({ selectedMonth: 11 });
-      this.props.getPrevYear();
-    } else {
-      this.setState({ selectedMonth: prev });
-    }
+      prev = 11;
+      this.props.getPrevYear(prev);
+    } 
 
-    this.props.onMonthChange(this.state.selectedMonth);
+    this.setState({ selectedMonth: prev });
+    this.props.onMonthChange(prev);
   },
 
   render() {
@@ -253,31 +251,38 @@ var CalendarPicker = React.createClass({
 
   onDayChange(day) {
     this.setState({day: day.day,});
-    this.onDateChange();
+    this.onDateChange({day: day.day,});
   },
 
   onMonthChange(month) {
+    // Don't update the date on a year change.
+    if (Math.abs(month - this.state.month) != 11) {
+      this.onDateChange({month: month,});
+    }
     this.setState({month: month,});
-    this.onDateChange();
   },
 
-  getNextYear(){
+  getNextYear(month){
+    this.onDateChange({
+      year: this.state.year + 1,
+      month: month,
+    });
     this.setState({year: this.state.year + 1,});
-    this.onDateChange();
   },
 
-  getPrevYear() {
+  getPrevYear(month) {
+    this.onDateChange({
+      year: this.state.year - 1,
+      month: month,
+    });
     this.setState({year: this.state.year - 1,});
-    this.onDateChange();
   },
 
-  onDateChange() {
-    var {
-      day,
-      month,
-      year
-    } = this.state,
-      date = new Date(year, month, day);
+  onDateChange(props) {
+    var year = typeof props.year == 'undefined' ? this.state.year : props.year,
+        month = typeof props.month == 'undefined' ? this.state.month : props.month,
+        day = typeof props.day == 'undefined' ? this.state.day : props.day,
+        date = new Date(year, month, day);
 
     this.setState({date: date,});
     this.props.onDateChange(date);


### PR DESCRIPTION
The setState method is done asynchronously in React Native. See this [link](https://facebook.github.io/react/docs/component-api.html#setstate).

>setState() does not immediately mutate this.state but creates a pending state transition. Accessing this.state after calling this method can potentially return the existing value.