### PR TITLE
Override Styles via property and programmatically set a different date.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.idea/

--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -329,8 +329,12 @@ var CalendarPicker = React.createClass({
     }
   },
 
-  simulateDateClick(day){
-    this.refs.days.onPressDay(day);
+  simulateDateClick(date){
+    this.setState({year: date.getFullYear(), month: date.getMonth(), date: date}, () => {
+      this.refs.headerControls.setState({selectedMonth: date.getMonth()}, () => {
+        this.refs.days.onPressDay(date.getDate());
+      })
+    });
   },
 
   render() {
@@ -344,7 +348,9 @@ var CalendarPicker = React.createClass({
           getPrevYear={this.getPrevYear}
           months={this.props.months}
           previousTitle={this.props.previousTitle}
-          nextTitle={this.props.nextTitle} />
+          nextTitle={this.props.nextTitle}
+          refs="headerControls"
+        />
 
         <WeekDaysLabels
           screenWidth={this.props.screenWidth}

--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -280,7 +280,8 @@ var CalendarPicker = React.createClass({
     nextTitle: React.PropTypes.string,
     selectedDayColor: React.PropTypes.string,
     selectedDayTextColor: React.PropTypes.string,
-    scaleFactor: React.PropTypes.number
+    scaleFactor: React.PropTypes.number,
+    overrideStyles: React.PropTypes.object
   },
   getDefaultProps() {
     return {
@@ -288,8 +289,8 @@ var CalendarPicker = React.createClass({
     };
   },
   getInitialState() {
-    if (this.props.scaleFactor !== undefined) {
-      styles = StyleSheet.create(makeStyles(this.props.scaleFactor));
+    if (this.props.scaleFactor !== undefined || this.props.overrideStyles !== undefined) {
+      styles = StyleSheet.create(makeStyles(this.props.scaleFactor, this.props.overrideStyles));
     }
     return {
       date: this.props.selectedDate,

--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -281,11 +281,13 @@ var CalendarPicker = React.createClass({
     selectedDayColor: React.PropTypes.string,
     selectedDayTextColor: React.PropTypes.string,
     scaleFactor: React.PropTypes.number,
-    overrideStyles: React.PropTypes.object
+    overrideStyles: React.PropTypes.object,
+    dontChangeDateOnCalendarMovement: React.PropTypes.bool
   },
   getDefaultProps() {
     return {
-      onDateChange () {}
+      onDateChange () {},
+      dontChangeDateOnCalendarMovement: false
     };
   },
   getInitialState() {
@@ -302,26 +304,25 @@ var CalendarPicker = React.createClass({
   },
 
   onDayChange(day) {
-    this.setState({day: day.day});
-    this.onDateChange();
+    this.setState({day: day.day}, () => {this.onDateChange();});
   },
 
   onMonthChange(month) {
     this.setState({month: month});
-    this.onDateChange();
+    this.onDateChange(this.props.dontChangeDateOnCalendarMovement);
   },
 
   getNextYear(){
     this.setState({year: this.state.year + 1});
-    this.onDateChange();
+    this.onDateChange(this.props.dontChangeDateOnCalendarMovement);
   },
 
   getPrevYear() {
     this.setState({year: this.state.year - 1});
-    this.onDateChange();
+    this.onDateChange(this.props.dontChangeDateOnCalendarMovement);
   },
 
-  onDateChange() {
+  onDateChange(changeDate=false) {
     var {
       day,
       month,
@@ -329,8 +330,10 @@ var CalendarPicker = React.createClass({
     } = this.state,
       date = new Date(year, month, day);
 
-    this.setState({date: date});
-    this.props.onDateChange(date);
+    if(changeDate) {
+      this.setState({date: date});
+      this.props.onDateChange(date);
+    }
   },
 
   simulateDateClick(day){

--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -333,6 +333,10 @@ var CalendarPicker = React.createClass({
     this.props.onDateChange(date);
   },
 
+  simulateDateClick(day){
+    this.refs.days.onPressDay(day);
+  },
+
   render() {
     return (
       <View style={styles.calendar}>
@@ -360,7 +364,8 @@ var CalendarPicker = React.createClass({
           styleSelectedDayText={this.props.styleSelectedDayText}
           startFromMonday={this.props.startFromMonday}
           selectedDayColor={this.props.selectedDayColor}
-          selectedDayTextColor={this.props.selectedDayTextColor}  />
+          selectedDayTextColor={this.props.selectedDayTextColor}
+          ref='days'/>
       </View>
     );
   }

--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -221,25 +221,21 @@ var HeaderControls = React.createClass({
   // could just let header controls hold all of the logic and have CalendarPicker
   // `onChange` callback fire and update itself on each change
   getNext() {
-    var next = this.state.selectedMonth + 1;
-    if (next > 11) {
-      this.setState({ selectedMonth: 0 });
-      this.props.getNextYear();
-    } else {
-      this.setState({ selectedMonth: next });
-    }
-    this.props.onMonthChange(this.state.selectedMonth);
+    let next = (this.state.selectedMonth + 1) % 12;
+
+    this.setState({selectedMonth: next}, () => {
+      if(next == 0){this.props.getNextYear()};
+      this.props.onMonthChange(this.state.selectedMonth);
+    });
   },
 
   getPrevious() {
-    var prev = this.state.selectedMonth - 1;
-    if (prev < 0) {
-      this.setState({ selectedMonth: 11 });
-      this.props.getPrevYear();
-    } else {
-      this.setState({ selectedMonth: prev });
-    }
-    this.props.onMonthChange(this.state.selectedMonth);
+    var prev = (this.state.selectedMonth + 11) % 12;
+
+    this.setState({ selectedMonth: prev}, () => {
+      if(prev == 11){this.props.getPrevYear()};
+      this.props.onMonthChange(this.state.selectedMonth);
+    });
   },
 
   render() {
@@ -282,12 +278,12 @@ var CalendarPicker = React.createClass({
     selectedDayTextColor: React.PropTypes.string,
     scaleFactor: React.PropTypes.number,
     overrideStyles: React.PropTypes.object,
-    dontChangeDateOnCalendarMovement: React.PropTypes.bool
+    changeDateOnCalendarMovement: React.PropTypes.bool
   },
   getDefaultProps() {
     return {
       onDateChange () {},
-      dontChangeDateOnCalendarMovement: false
+      changeDateOnCalendarMovement: true
     };
   },
   getInitialState() {
@@ -304,25 +300,23 @@ var CalendarPicker = React.createClass({
   },
 
   onDayChange(day) {
-    this.setState({day: day.day}, () => {this.onDateChange();});
+    // onDayChange is called when the user selects a date, so we want to always call onDateChange with true
+    this.setState({day: day.day}, () => {this.onDateChange(true)});
   },
 
   onMonthChange(month) {
-    this.setState({month: month});
-    this.onDateChange(this.props.dontChangeDateOnCalendarMovement);
+    this.setState({month: month}, () => {this.onDateChange(this.props.changeDateOnCalendarMovement)});
   },
 
   getNextYear(){
-    this.setState({year: this.state.year + 1});
-    this.onDateChange(this.props.dontChangeDateOnCalendarMovement);
+    this.setState({year: this.state.year + 1}, () => {this.onDateChange(this.props.changeDateOnCalendarMovement)});
   },
 
   getPrevYear() {
-    this.setState({year: this.state.year - 1});
-    this.onDateChange(this.props.dontChangeDateOnCalendarMovement);
+    this.setState({year: this.state.year - 1}, () => {this.onDateChange(this.props.changeDateOnCalendarMovement)});
   },
 
-  onDateChange(changeDate=false) {
+  onDateChange(changeDate=true) {
     var {
       day,
       month,
@@ -331,8 +325,7 @@ var CalendarPicker = React.createClass({
       date = new Date(year, month, day);
 
     if(changeDate) {
-      this.setState({date: date});
-      this.props.onDateChange(date);
+      this.setState({date: date}, () => {this.props.onDateChange(date)});
     }
   },
 

--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -349,7 +349,7 @@ var CalendarPicker = React.createClass({
           months={this.props.months}
           previousTitle={this.props.previousTitle}
           nextTitle={this.props.nextTitle}
-          refs="headerControls"
+          ref="headerControls"
         />
 
         <WeekDaysLabels

--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -224,7 +224,7 @@ var HeaderControls = React.createClass({
     let next = (this.state.selectedMonth + 1) % 12;
 
     this.setState({selectedMonth: next}, () => {
-      if(next == 0){this.props.getNextYear()};
+      if(next == 0){this.props.getNextYear();}
       this.props.onMonthChange(this.state.selectedMonth);
     });
   },
@@ -233,7 +233,7 @@ var HeaderControls = React.createClass({
     var prev = (this.state.selectedMonth + 11) % 12;
 
     this.setState({ selectedMonth: prev}, () => {
-      if(prev == 11){this.props.getPrevYear()};
+      if(prev == 11){this.props.getPrevYear();}
       this.props.onMonthChange(this.state.selectedMonth);
     });
   },
@@ -301,19 +301,19 @@ var CalendarPicker = React.createClass({
 
   onDayChange(day) {
     // onDayChange is called when the user selects a date, so we want to always call onDateChange with true
-    this.setState({day: day.day}, () => {this.onDateChange(true)});
+    this.setState({day: day.day}, () => {this.onDateChange(true);});
   },
 
   onMonthChange(month) {
-    this.setState({month: month}, () => {this.onDateChange(this.props.changeDateOnCalendarMovement)});
+    this.setState({month: month}, () => {this.onDateChange(this.props.changeDateOnCalendarMovement);});
   },
 
   getNextYear(){
-    this.setState({year: this.state.year + 1}, () => {this.onDateChange(this.props.changeDateOnCalendarMovement)});
+    this.setState({year: this.state.year + 1}, () => {this.onDateChange(this.props.changeDateOnCalendarMovement);});
   },
 
   getPrevYear() {
-    this.setState({year: this.state.year - 1}, () => {this.onDateChange(this.props.changeDateOnCalendarMovement)});
+    this.setState({year: this.state.year - 1}, () => {this.onDateChange(this.props.changeDateOnCalendarMovement);});
   },
 
   onDateChange(changeDate=true) {
@@ -325,7 +325,7 @@ var CalendarPicker = React.createClass({
       date = new Date(year, month, day);
 
     if(changeDate) {
-      this.setState({date: date}, () => {this.props.onDateChange(date)});
+      this.setState({date: date}, () => {this.props.onDateChange(date);});
     }
   },
 
@@ -333,7 +333,7 @@ var CalendarPicker = React.createClass({
     this.setState({year: date.getFullYear(), month: date.getMonth(), date: date}, () => {
       this.refs.headerControls.setState({selectedMonth: date.getMonth()}, () => {
         this.refs.days.onPressDay(date.getDate());
-      })
+      });
     });
   },
 

--- a/CalendarPicker/makeStyles.js
+++ b/CalendarPicker/makeStyles.js
@@ -6,7 +6,9 @@
  */
 'use strict';
 
-function makeStyles(scaler) {
+var _ = require('lodash');
+
+function defaultStyles(scaler) {
   return {
     calendar: {
       height: 320*scaler,
@@ -118,5 +120,8 @@ function makeStyles(scaler) {
   };
 }
 
+function makeStyles(scaler, overrideStyles){
+  return _.merge({}, defaultStyles(scaler), overrideStyles);
+}
 
 module.exports = makeStyles;

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ const styles = StyleSheet.create({
 | nextTitle | string | Title of button for next month. |
 | selectedDayColor | string | Color for selected day |
 | scaleFactor | float | Optional. Default scales to window width |
-
+| changeDateOnCalendarMovement | bool | Optional. Defaults to true, thus changing the year or month will also change the selcted date. Set to false if you don't want that. |
+| overrideStyles | object | Optional. With this you can override all default styles present in makeStyles.js. This uses lodash to merge the override styles onto the default styles. |
 
 # To Do:
 

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
       "promise",
       "source-map"
     ]
+  },
+  "dependencies": {
+    "lodash": "^4.13.1"
   }
 }


### PR DESCRIPTION
With the override styles property it is now possible to override every style used in the calendar picker component. This is accomplished by using lodash and merging the default styles with the override styles.

If the displayed date changes without user interaction (e.g. async load from db) the method simulateDateClick(date) can be called to set the calendar to this date.

Refactored the setState calls, since setState is async.
