### PR TITLE
No need for `{day: day}`. Just use `day`.

### DIFF
--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -132,7 +132,7 @@ var Days = React.createClass({
 
   onPressDay(day) {
     this.updateSelectedStates(day);
-    this.props.onDayChange({day: day});
+    this.props.onDayChange(day);
   },
 
   // Not going to touch this one - I'd look at whether there is a more functional
@@ -323,7 +323,7 @@ var CalendarPicker = React.createClass({
   },
 
   onDayChange(day) {
-    this.setState({day: day.day}, () => { this.onDateChange(); });
+    this.setState({day: day,}, () => { this.onDateChange(); });
   },
 
   onMonthChange(month) {


### PR DESCRIPTION
Tested in production and works fine.
