### PR TITLE
Add min date and max date

### DIFF
--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -283,12 +283,27 @@ var HeaderControls = React.createClass({
     }
   },
 
+  previousMonthDisabled() {
+    return ( this.props.minDate &&
+             ( this.props.year < this.props.minDate.getFullYear() ||
+               ( this.props.year == this.props.minDate.getFullYear() && this.state.selectedMonth <= this.props.minDate.getMonth() )
+             )
+           );
+  },
+
+  nextMonthDisabled() {
+    return ( this.props.maxDate &&
+             ( this.props.year > this.props.maxDate.getFullYear() ||
+               ( this.props.year == this.props.maxDate.getFullYear() && this.state.selectedMonth >= this.props.maxDate.getMonth() )
+             )
+           );
+  },
+
   render() {
     var textStyle = this.props.textStyle;
 
     var previous;
-    if ( this.props.year < this.props.minDate.getFullYear() ||
-         ( this.props.year == this.props.minDate.getFullYear() && this.state.selectedMonth <= this.props.minDate.getMonth() ) ) {
+    if ( this.previousMonthDisabled() ) {
       previous = (
         <Text style={[styles.prev, textStyle, styles.disabledTextColor]}>{this.props.previousTitle || 'Previous'}</Text>
       )
@@ -302,8 +317,7 @@ var HeaderControls = React.createClass({
     }
 
     var next;
-    if ( this.props.year > this.props.maxDate.getFullYear() ||
-         ( this.props.year == this.props.maxDate.getFullYear() && this.state.selectedMonth >= this.props.maxDate.getMonth() ) ) {
+    if ( this.nextMonthDisabled() ) {
       next = (
         <Text style={[styles.next, textStyle, styles.disabledTextColor]}>{this.props.nextTitle || 'Next'}</Text>
       )

--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -32,7 +32,10 @@ var styles = StyleSheet.create(makeStyles(initialScale));
 
 var Day = React.createClass({
   propTypes: {
+    date: React.PropTypes.instanceOf(Date),
     onDayChange: React.PropTypes.func,
+    maxDate: React.PropTypes.instanceOf(Date),
+    minDate: React.PropTypes.instanceOf(Date),
     selected: React.PropTypes.bool,
     day: React.PropTypes.oneOfType([
       React.PropTypes.number,
@@ -76,23 +79,36 @@ var Day = React.createClass({
         </View>
       );
     } else {
-      return (
-        <View style={styles.dayWrapper}>
-          <TouchableOpacity
-            style={styles.dayButton}
-            onPress={() => this.props.onDayChange(this.props.day) }>
-            <Text style={[styles.dayLabel, textStyle]}>
+	  if (this.props.date < this.props.minDate || this.props.date > this.props.maxDate) {
+        return (
+          <View style={styles.dayWrapper}>
+            <Text style={[styles.dayLabel, textStyle, styles.disabledTextColor]}>
               {this.props.day}
             </Text>
-          </TouchableOpacity>
-        </View>
-      );
+          </View>
+        );
+      } 
+      else {
+        return (
+          <View style={styles.dayWrapper}>
+            <TouchableOpacity
+              style={styles.dayButton}
+              onPress={() => this.props.onDayChange(this.props.day) }>
+              <Text style={[styles.dayLabel, textStyle]}>
+                {this.props.day}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        );
+      }
     }
   }
 });
 
 var Days = React.createClass({
   propTypes: {
+    maxDate: React.PropTypes.instanceOf(Date),
+    minDate: React.PropTypes.instanceOf(Date),
     date: React.PropTypes.instanceOf(Date).isRequired,
     month: React.PropTypes.number.isRequired,
     year: React.PropTypes.number.isRequired,
@@ -160,7 +176,9 @@ var Days = React.createClass({
                       key={j}
                       day={currentDay+1}
                       selected={this.state.selectedStates[currentDay]}
-                      date={this.props.date}
+                      date={new Date(year, month, currentDay + 1)}
+                      maxDate={this.props.maxDate}
+                      minDate={this.props.minDate}
                       onDayChange={this.onPressDay}
                       screenWidth={this.props.screenWidth}
                       selectedDayColor={this.props.selectedDayColor}
@@ -211,6 +229,7 @@ var WeekDaysLabels = React.createClass({
 var HeaderControls = React.createClass({
   propTypes: {
     month: React.PropTypes.number.isRequired,
+    year: React.PropTypes.number,
     getNextYear: React.PropTypes.func.isRequired,
     getPrevYear: React.PropTypes.func.isRequired,
     onMonthChange: React.PropTypes.func.isRequired,
@@ -266,12 +285,41 @@ var HeaderControls = React.createClass({
 
   render() {
     var textStyle = this.props.textStyle;
+
+    var previous;
+    if ( this.props.year < this.props.minDate.getFullYear() ||
+         ( this.props.year == this.props.minDate.getFullYear() && this.state.selectedMonth <= this.props.minDate.getMonth() ) ) {
+      previous = (
+        <Text style={[styles.prev, textStyle, styles.disabledTextColor]}>{this.props.previousTitle || 'Previous'}</Text>
+      )
+    }
+    else {
+      previous = (
+        <TouchableOpacity onPress={this.getPrevious}>
+          <Text style={[styles.prev, textStyle]}>{this.props.previousTitle || 'Previous'}</Text>
+        </TouchableOpacity>
+      )
+    }
+
+    var next;
+    if ( this.props.year > this.props.maxDate.getFullYear() ||
+         ( this.props.year == this.props.maxDate.getFullYear() && this.state.selectedMonth >= this.props.maxDate.getMonth() ) ) {
+      next = (
+        <Text style={[styles.next, textStyle, styles.disabledTextColor]}>{this.props.nextTitle || 'Next'}</Text>
+      )
+    }
+    else {
+      next = (
+        <TouchableOpacity onPress={this.getNext}>
+          <Text style={[styles.next, textStyle]}>{this.props.nextTitle || 'Next'}</Text>
+        </TouchableOpacity>
+      )
+    }
+
     return (
       <View style={styles.headerWrapper}>
         <View style={styles.monthSelector}>
-          <TouchableOpacity onPress={this.getPrevious}>
-            <Text style={[styles.prev, textStyle]}>{this.props.previousTitle || 'Previous'}</Text>
-          </TouchableOpacity>
+          {previous}
         </View>
         <View>
           <Text style={[styles.monthLabel, textStyle]}>
@@ -279,9 +327,7 @@ var HeaderControls = React.createClass({
           </Text>
         </View>
         <View style={styles.monthSelector}>
-          <TouchableOpacity onPress={this.getNext}>
-            <Text style={[styles.next, textStyle]}>{this.props.nextTitle || 'Next'}</Text>
-          </TouchableOpacity>
+          {next}
         </View>
 
       </View>
@@ -291,6 +337,8 @@ var HeaderControls = React.createClass({
 
 var CalendarPicker = React.createClass({
   propTypes: {
+    maxDate: React.PropTypes.instanceOf(Date),
+    minDate: React.PropTypes.instanceOf(Date),
     selectedDate: React.PropTypes.instanceOf(Date).isRequired,
     onDateChange: React.PropTypes.func,
     screenWidth: React.PropTypes.number.isRequired,
@@ -354,6 +402,8 @@ var CalendarPicker = React.createClass({
     return (
       <View style={styles.calendar}>
         <HeaderControls
+          maxDate={this.props.maxDate}
+          minDate={this.props.minDate}
           year={this.state.year}
           month={this.state.month}
           onMonthChange={this.onMonthChange}
@@ -370,6 +420,8 @@ var CalendarPicker = React.createClass({
           textStyle={this.props.textStyle} />
 
         <Days
+          maxDate={this.props.maxDate}
+          minDate={this.props.minDate}
           month={this.state.month}
           year={this.state.year}
           date={this.state.date}

--- a/CalendarPicker/makeStyles.js
+++ b/CalendarPicker/makeStyles.js
@@ -114,7 +114,11 @@ function makeStyles(scaler) {
 
     weekRow: {
       flexDirection: 'row'
-    }
+    },
+
+    disabledTextColor: {
+      color: '#BBBBBB',
+    },
   };
 }
 


### PR DESCRIPTION
Disables the day if it's less than `minDate` or greater than `maxDate`.

Also disables next and previous links when appropriate.

Fixes #37.

For example, the following initialization:

```js
<CalendarPicker minDate={new Date(2016,6,4)} maxDate={new Date(2016,6,25)} />
```

Will produce the following:

![screenshot 2016-07-07 12 30 15](https://cloud.githubusercontent.com/assets/180819/16664722/95dc4f92-443e-11e6-8c6d-f01038b58acf.png)

And with only `maxDate`:

```js
<CalendarPicker maxDate={new Date(2016,6,25)} />
```

![screenshot 2016-07-07 12 40 07](https://cloud.githubusercontent.com/assets/180819/16665303/517fcfe8-4440-11e6-86df-86326a0563ef.png)

And with only `minDate`:

```js
<CalendarPicker minDate={new Date(2016,6,4)} />
```

![screenshot 2016-07-07 12 40 58](https://cloud.githubusercontent.com/assets/180819/16665315/5e294242-4440-11e6-84d0-d56a025dc785.png)

