### PR TITLE
Update Calendar on Props Change.

### DIFF
--- a/CalendarPicker/CalendarPicker.js
+++ b/CalendarPicker/CalendarPicker.js
@@ -111,6 +111,13 @@ var Days = React.createClass({
     this.updateSelectedStates(this.props.date.getDate());
   },
 
+  // Trigger date change if new props are provided.
+  // Typically, when selectedDate is changed programmatically.
+  //
+  componentWillReceiveProps: function(newProps) {
+    this.updateSelectedStates(newProps.date.getDate());
+  },
+
   updateSelectedStates(day) {
     var selectedStates = [],
       daysInMonth = getDaysInMonth(this.props.month, this.props.year),
@@ -222,6 +229,15 @@ var HeaderControls = React.createClass({
     };
   },
 
+  // Trigger date change if new props are provided.
+  // Typically, when selectedDate is changed programmatically.
+  //
+  componentWillReceiveProps: function(newProps) {
+    this.setState({
+      selectedMonth: newProps.month
+    });
+  },
+
   // Logic seems a bit awkawardly split up between here and the CalendarPicker
   // component, eg: getNextYear is actually modifying the state of the parent,
   // could just let header controls hold all of the logic and have CalendarPicker
@@ -320,6 +336,18 @@ var CalendarPicker = React.createClass({
       year: this.props.selectedDate.getFullYear(),
       selectedDay: []
     };
+  },
+
+  // Trigger date change if new props are provided.
+  // Typically, when selectedDate is changed programmatically.
+  //
+  componentWillReceiveProps: function(newProps) {
+    this.setState({
+      date:  newProps.selectedDate,
+      day:   newProps.selectedDate.getDate(),
+      month: newProps.selectedDate.getMonth(),
+      year:  newProps.selectedDate.getFullYear(),
+    });
   },
 
   onDayChange(day) {


### PR DESCRIPTION
This is necessary when you're changing the `selectedDate` prop of CalenderPicker programmatically.

For example, in our app after a user selects a date and clicks submit, we reset the form and set the CalendarPicker selectedDate to `new Date()`. However, the CalendarPicker calendar doesn't actually update.

This commit adds `componentWillReceiveProps`, which watches for new props passed to CalendarPicker and updates based on the new Props.

Works great! :)