### PR TITLE
Prop initialDate controls which date/month calendar opens to.

### DIFF
--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -24,23 +24,26 @@ export default class CalendarPicker extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      initialDate: null,
       currentMonth: null,
       currentYear: null,
       selectedStartDate: null,
       selectedEndDate: null,
       styles: {},
     };
+    this.updateMonthYear = this.updateMonthYear.bind(this);
     this.handleOnPressPrevious = this.handleOnPressPrevious.bind(this);
     this.handleOnPressNext = this.handleOnPressNext.bind(this);
     this.handleOnPressDay = this.handleOnPressDay.bind(this);
     this.onSwipe = this.onSwipe.bind(this);
   }
 
+  static defaultProps = {
+    initialDate: new Date()
+  }
+
   componentWillMount() {
     const {
       scaleFactor,
-      initialDate,
       selectedDayColor,
       selectedDayTextColor,
       todayBackgroundColor,
@@ -50,13 +53,21 @@ export default class CalendarPicker extends Component {
     const deviceWidth = Dimensions.get('window').width;
     const initialScale = scaleFactor? deviceWidth / scaleFactor : deviceWidth / 375;
     const styles = makeStyles(initialScale, selectedDayColor, selectedDayTextColor, todayBackgroundColor);
-    const date = initialDate ? initialDate : new Date();
 
+    this.updateMonthYear(this.props, {styles});
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.initialDate.getTime() !== this.props.initialDate.getTime()) {
+      this.updateMonthYear(nextProps, {});
+    }
+  }
+
+  updateMonthYear(props, addtlState) {
     this.setState({
-      initialDate: date,
-      currentMonth: parseInt(date.getMonth()),
-      currentYear: parseInt(date.getFullYear()),
-      styles,
+      currentMonth: parseInt(props.initialDate.getMonth()),
+      currentYear: parseInt(props.initialDate.getFullYear()),
+      ...addtlState
     });
   }
 
@@ -143,7 +154,6 @@ export default class CalendarPicker extends Component {
 
   render() {
     const {
-      initialDate,
       currentMonth,
       currentYear,
       selectedStartDate,
@@ -154,6 +164,7 @@ export default class CalendarPicker extends Component {
     const {
       allowRangeSelection,
       startFromMonday,
+      initialDate,
       minDate,
       maxDate,
       weekdays,

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ const styles = StyleSheet.create({
 | **`scaleFactor`** | `Number` | Optional. Default scales to window width |
 | **`minDate`** | `Date` | Optional. Specifies minimum date to be selected |
 | **`maxDate`** | `Date` | Optional. Specifies maximum date to be selected |
+| **`initialDate`** | `Date` | Optional. Date that calendar opens to. Defaults to today. |
 
 # Styles
 Some styles will overwrite some won't. For instance:


### PR DESCRIPTION
The render() method refers to `initialDate` in props instead of state, allowing the parent to change initialDate and automatically update via render().  `currentMonth` and `currentYear` reference the initialDate prop, initially in componentDidMount and also as it's updated in componentWillReceiveProps.

If the parent does not pass in `initialDate`, it defaults to today.