### PR TITLE
Fix state update when initialDate prop changes. Add onMonthChange prop.

### DIFF
--- a/CalendarPicker/Controls.js
+++ b/CalendarPicker/Controls.js
@@ -1,8 +1,9 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {
   TouchableOpacity,
   Text,
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 export default function Controls({ styles, textStyles, label, onPressControl }) {
   return (

--- a/CalendarPicker/Day.js
+++ b/CalendarPicker/Day.js
@@ -1,9 +1,10 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {
   View,
   Text,
   TouchableOpacity
 } from 'react-native';
+import PropTypes from 'prop-types';
 import { Utils } from './Utils';
 
 export default function Day(props) {

--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -1,9 +1,10 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import uuid from 'uuid';
 import {
   View,
   Text,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import Day from './Day';
 import EmptyDay from './EmptyDay';
 import { Utils } from './Utils';

--- a/CalendarPicker/EmptyDay.js
+++ b/CalendarPicker/EmptyDay.js
@@ -1,9 +1,10 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {
   View,
   Text,
   TouchableOpacity
 } from 'react-native';
+import PropTypes from 'prop-types';
 
 export default function Day(props) {
   const { styles } = props;

--- a/CalendarPicker/HeaderControls.js
+++ b/CalendarPicker/HeaderControls.js
@@ -1,8 +1,9 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {
   View,
   Text,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import { Utils } from './Utils';
 import Controls from './Controls';
 

--- a/CalendarPicker/Weekdays.js
+++ b/CalendarPicker/Weekdays.js
@@ -1,8 +1,9 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import {
   View,
   Text,
 } from 'react-native';
+import PropTypes from 'prop-types';
 import { Utils } from './Utils';
 
 export default function Weekdays(props) {

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -49,18 +49,24 @@ export default class CalendarPicker extends Component {
 
   componentWillReceiveProps(nextProps) {
     let newStyles = {};
+    let doStateUpdate = false;
+
     if (nextProps.width !== this.props.width ||
         nextProps.height !== this.props.height)
     {
       newStyles = this.updateScaledStyles(nextProps);
+      doStateUpdate = true;
     }
 
-    let newMonthYear = {}
+    let newMonthYear = {};
     if (nextProps.initialDate.getTime() !== this.props.initialDate.getTime()) {
-      newMonthYear = {...this.updateMonthYear(nextProps.initialDate)};
+      newMonthYear = this.updateMonthYear(nextProps.initialDate);
+      doStateUpdate = true;
     }
 
-    this.setState({...newStyles, ...newMonthYear});
+    if (doStateUpdate) {
+      this.setState({...newStyles, ...newMonthYear});
+    }
   }
 
   updateScaledStyles(props) {

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -44,7 +44,7 @@ export default class CalendarPicker extends Component {
   }
 
   componentWillMount() {
-    this.setState({...this.updateScaledStyles(this.props), ...this.updateMonthYear(this.props)});
+    this.setState({...this.updateScaledStyles(this.props), ...this.updateMonthYear(this.props.initialDate)});
   }
 
   componentWillReceiveProps(nextProps) {
@@ -57,7 +57,7 @@ export default class CalendarPicker extends Component {
 
     let newMonthYear = {}
     if (nextProps.initialDate.getTime() !== this.props.initialDate.getTime()) {
-      this.updateMonthYear(nextProps, {});
+      newMonthYear = {...this.updateMonthYear(nextProps.initialDate)};
     }
 
     this.setState({...newStyles, ...newMonthYear});
@@ -79,10 +79,10 @@ export default class CalendarPicker extends Component {
     return {styles: makeStyles(initialScale, selectedDayColor, selectedDayTextColor, todayBackgroundColor)};
   }
 
-  updateMonthYear(props) {
+  updateMonthYear(initialDate = this.props.initialDate) {
     return {
-      currentMonth: parseInt(props.initialDate.getMonth()),
-      currentYear: parseInt(props.initialDate.getFullYear()),
+      currentMonth: parseInt(initialDate.getMonth()),
+      currentYear: parseInt(initialDate.getFullYear()),
     };
   }
 
@@ -121,14 +121,16 @@ export default class CalendarPicker extends Component {
   }
 
   handleOnPressPrevious() {
-    const { currentMonth, currentYear } = this.state;
-    const previousMonth = currentMonth - 1;
+    let { currentMonth, currentYear } = this.state;
+    let previousMonth = currentMonth - 1;
     // if previousMonth is negative it means the current month is January,
     // so we have to go back to previous year and set the current month to December
     if (previousMonth < 0) {
+      previousMonth = 11;
+      currentYear -= 1;  // decrement year
       this.setState({
-        currentMonth: parseInt(11), // setting month to December
-        currentYear: parseInt(currentYear) - 1, // decrement year
+        currentMonth: parseInt(previousMonth), // setting month to December
+        currentYear: parseInt(currentYear),
       });
     } else {
       this.setState({
@@ -136,17 +138,20 @@ export default class CalendarPicker extends Component {
         currentYear: parseInt(currentYear),
       });
     }
+    this.props.onMonthChange && this.props.onMonthChange(new Date(currentYear, previousMonth));
   }
 
   handleOnPressNext() {
-    const { currentMonth, currentYear } = this.state;
-    const nextMonth = currentMonth + 1;
+    let { currentMonth, currentYear } = this.state;
+    let nextMonth = currentMonth + 1;
     // if nextMonth is greater than 11 it means the current month is December,
     // so we have to go forward to the next year and set the current month to January
     if (nextMonth > 11) {
+      nextMonth = 0;
+      currentYear += 1;  // increment year
       this.setState({
-        currentMonth: parseInt(0), // setting month to January
-        currentYear: parseInt(currentYear) + 1, // increment year
+        currentMonth: parseInt(nextMonth), // setting month to January
+        currentYear: parseInt(currentYear),
       });
     } else {
       this.setState({
@@ -154,6 +159,7 @@ export default class CalendarPicker extends Component {
         currentYear: parseInt(currentYear),
       });
     }
+    this.props.onMonthChange && this.props.onMonthChange(new Date(currentYear, nextMonth));
   }
 
   onSwipe(gestureName) {

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ const styles = StyleSheet.create({
 | **`initialDate`** | `Date` | Optional. Date that calendar opens to. Defaults to today. |
 | **`width`** | `Number` | Optional. Width of CalendarPicker's container. Defaults to Dimensions width.|
 | **`height`** | `Number` | Optional. Height of CalendarPicker's container. Defaults to Dimensions height.|
+| **`onDateChange`** | `Function` | Optional. Callback when a date is selected. Returns `date` as first parameter.|
+| **`onMonthChange`** | `Function` | Optional. Callback when Previous / Next month is pressed. Returns `date` as first parameter.|
 
 # Styles
 Some styles will overwrite some won't. For instance:

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
   "directories": {},
   "_resolved": "https://registry.npmjs.org/react-native-calendar-picker/-/react-native-calendar-picker-1.0.1.tgz",
   "dependencies": {
-    "react-native": "^0.42.3",
     "expo": "^15.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "react-native-calendar-picker",
   "version": "5.9.0",
   "description": "Calendar Picker Component for React Native",
-  "engines" : {
-    "node" : ">=7.6.0"
+  "engines": {
+    "node": ">=7.6.0"
   },
   "devDependencies": {
     "jest-expo": "^0.3.0",
@@ -73,6 +73,7 @@
   "directories": {},
   "_resolved": "https://registry.npmjs.org/react-native-calendar-picker/-/react-native-calendar-picker-1.0.1.tgz",
   "dependencies": {
-    "expo": "^15.1.0"
+    "expo": "^15.1.0",
+    "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
onMonthChange fires when Previous/Next is pressed.

[Line 60](https://github.com/stephy/CalendarPicker/pull/84/commits/2db5ec8af910ed73414f1c41e8003f20781d331d#diff-0b829010e731eca6770ccc0d87c6a789R60) fixes the `intitialDate`prop change state update.

See #83