### PR TITLE
add dayShape props

### DIFF
--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -35,7 +35,7 @@ export default function DaysGridView(props) {
     disabledDates,
     minRangeDuration,
     maxRangeDuration,
-    enableDateChange,
+    enableDateChange
   } = props;
   const today = moment();
   // let's get the total of days in this month, we need the year as well, since

--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -35,7 +35,7 @@ export default function DaysGridView(props) {
     disabledDates,
     minRangeDuration,
     maxRangeDuration,
-    enableDateChange
+    enableDateChange,
   } = props;
   const today = moment();
   // let's get the total of days in this month, we need the year as well, since

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -99,7 +99,7 @@ export default class CalendarPicker extends Component {
       todayBackgroundColor,
       width,
       height,
-      gridShape
+      dayShape
     } = props;
 
     // The styles in makeStyles are intially scaled to this width
@@ -113,7 +113,7 @@ export default class CalendarPicker extends Component {
         selectedDayColor,
         selectedDayTextColor,
         todayBackgroundColor,
-        gridShape
+        dayShape
       )
     };
   }

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -260,7 +260,7 @@ export default class CalendarPicker extends Component {
       maxRangeDuration,
       swipeConfig,
       customDatesStyles,
-      enableDateChange,
+      enableDateChange
     } = this.props;
 
     let disabledDatesTime = [];

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -98,7 +98,8 @@ export default class CalendarPicker extends Component {
       selectedDayTextColor,
       todayBackgroundColor,
       width,
-      height
+      height,
+      gridShape
     } = props;
 
     // The styles in makeStyles are intially scaled to this width
@@ -111,7 +112,8 @@ export default class CalendarPicker extends Component {
         initialScale,
         selectedDayColor,
         selectedDayTextColor,
-        todayBackgroundColor
+        todayBackgroundColor,
+        gridShape
       )
     };
   }
@@ -258,7 +260,7 @@ export default class CalendarPicker extends Component {
       maxRangeDuration,
       swipeConfig,
       customDatesStyles,
-      enableDateChange
+      enableDateChange,
     } = this.props;
 
     let disabledDatesTime = [];

--- a/CalendarPicker/makeStyles.js
+++ b/CalendarPicker/makeStyles.js
@@ -6,12 +6,21 @@
  */
 const DEFAULT_SELECTED_BACKGROUND_COLOR = '#5ce600';
 const DEFAULT_SELECTED_TEXT_COLOR = '#000000';
-const DEFAULT_TODAY_BACKGROUD_COLOR = '#CCCCCC';
+const DEFAULT_TODAY_BACKGROUND_COLOR = '#CCCCCC';
 
-export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundColor) {
+function getBorderRadiusByShape(scaler, gridShape) {
+  if (gridShape === 'square') {
+    return 0;
+  } else {
+    return 30 * scaler;
+  }
+}
+
+export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundColor, gridShape) {
   const SELECTED_BG_COLOR = backgroundColor ? backgroundColor : DEFAULT_SELECTED_BACKGROUND_COLOR;
   const SELECTED_TEXT_COLOR = textColor ? textColor : DEFAULT_SELECTED_TEXT_COLOR;
-  const TODAY_BG_COLOR = todayBackgroundColor ? todayBackgroundColor : DEFAULT_TODAY_BACKGROUD_COLOR;
+  const TODAY_BG_COLOR = todayBackgroundColor ? todayBackgroundColor : DEFAULT_TODAY_BACKGROUND_COLOR;
+
   return {
     calendar: {
       height: 320*scaler,
@@ -21,7 +30,7 @@ export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundCo
     dayButton: {
       width: 30*scaler,
       height: 30*scaler,
-      borderRadius: 30*scaler,
+      borderRadius: getBorderRadiusByShape(scaler, gridShape),
       alignSelf: 'center',
       justifyContent: 'center'
     },
@@ -63,7 +72,7 @@ export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundCo
     selectedDay: {
       width: 30*scaler,
       height:30*scaler,
-      borderRadius: 30*scaler,
+      borderRadius: getBorderRadiusByShape(scaler, gridShape),
       alignSelf: 'center',
       justifyContent: 'center'
     },
@@ -76,7 +85,7 @@ export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundCo
       width: 30*scaler,
       height:30*scaler,
       backgroundColor: TODAY_BG_COLOR,
-      borderRadius: 30*scaler,
+      borderRadius: getBorderRadiusByShape(scaler, gridShape),
       alignSelf: 'center',
       justifyContent: 'center'
     },

--- a/CalendarPicker/makeStyles.js
+++ b/CalendarPicker/makeStyles.js
@@ -8,15 +8,15 @@ const DEFAULT_SELECTED_BACKGROUND_COLOR = '#5ce600';
 const DEFAULT_SELECTED_TEXT_COLOR = '#000000';
 const DEFAULT_TODAY_BACKGROUND_COLOR = '#CCCCCC';
 
-function getBorderRadiusByShape(scaler, gridShape) {
-  if (gridShape === 'square') {
+function getBorderRadiusByShape(scaler, dayShape) {
+  if (dayShape === 'square') {
     return 0;
   } else {
     return 30*scaler;
   }
 }
 
-export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundColor, gridShape) {
+export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundColor, dayShape) {
   const SELECTED_BG_COLOR = backgroundColor ? backgroundColor : DEFAULT_SELECTED_BACKGROUND_COLOR;
   const SELECTED_TEXT_COLOR = textColor ? textColor : DEFAULT_SELECTED_TEXT_COLOR;
   const TODAY_BG_COLOR = todayBackgroundColor ? todayBackgroundColor : DEFAULT_TODAY_BACKGROUND_COLOR;
@@ -30,7 +30,7 @@ export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundCo
     dayButton: {
       width: 30*scaler,
       height: 30*scaler,
-      borderRadius: getBorderRadiusByShape(scaler, gridShape),
+      borderRadius: getBorderRadiusByShape(scaler, dayShape),
       alignSelf: 'center',
       justifyContent: 'center'
     },
@@ -72,7 +72,7 @@ export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundCo
     selectedDay: {
       width: 30*scaler,
       height:30*scaler,
-      borderRadius: getBorderRadiusByShape(scaler, gridShape),
+      borderRadius: getBorderRadiusByShape(scaler, dayShape),
       alignSelf: 'center',
       justifyContent: 'center'
     },
@@ -85,7 +85,7 @@ export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundCo
       width: 30*scaler,
       height:30*scaler,
       backgroundColor: TODAY_BG_COLOR,
-      borderRadius: getBorderRadiusByShape(scaler, gridShape),
+      borderRadius: getBorderRadiusByShape(scaler, dayShape),
       alignSelf: 'center',
       justifyContent: 'center'
     },

--- a/CalendarPicker/makeStyles.js
+++ b/CalendarPicker/makeStyles.js
@@ -12,7 +12,7 @@ function getBorderRadiusByShape(scaler, gridShape) {
   if (gridShape === 'square') {
     return 0;
   } else {
-    return 30 * scaler;
+    return 30*scaler;
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ const styles = StyleSheet.create({
 | **`onDateChange`** | `Function` | Optional. Callback when a date is selected. Returns Moment `date` as first parameter.|
 | **`onMonthChange`** | `Function` | Optional. Callback when Previous / Next month is pressed. Returns Moment `date` as first parameter.|
 | **`onSwipe`** | `Function` | Optional. Callback when swipe event is triggered. Returns swipe direction as first parameter.|
-| **`gridShape`** | `String` | Optional. Default is `circle`. Available options are `circle` and `square`.|
+| **`dayShape`** | `String` | Optional. Shape of the Day component. Default is `circle`. Available options are `circle` and `square`.|
 
 # Styles
 Some styles will overwrite some won't. For instance:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ const styles = StyleSheet.create({
 | **`onDateChange`** | `Function` | Optional. Callback when a date is selected. Returns Moment `date` as first parameter.|
 | **`onMonthChange`** | `Function` | Optional. Callback when Previous / Next month is pressed. Returns Moment `date` as first parameter.|
 | **`onSwipe`** | `Function` | Optional. Callback when swipe event is triggered. Returns swipe direction as first parameter.|
+| **`gridShape`** | `String` | Optional. Default is `circle`. Available options are `circle` and `square`.|
 
 # Styles
 Some styles will overwrite some won't. For instance:


### PR DESCRIPTION
This PR adds a prop that enables a "square" shape on selected days, instead of the default circle. Also fixed a typo on `DEFAULT_TODAY_BACKGROUND_COLOR` in makeStyles.