### PR TITLE
Fixed the tests with the minimum number of changes.

### DIFF
--- a/CalendarPicker/__tests__/CalendarPicker-test.js
+++ b/CalendarPicker/__tests__/CalendarPicker-test.js
@@ -39,6 +39,7 @@ describe('CalendarPicker', function() {
 		const CalendarPicker = renderer.create(
 			<CalenderPicker
 				allowRangeSelection={true}
+				initialDate={new Date(2019, 1, 20)}
 				selectedStartDate={selectedStartDate}
 				selectedEndDate={selectedEndDate}
 				onDateChange={() => {}}

--- a/CalendarPicker/__tests__/__snapshots__/CalendarPicker-test.js.snap
+++ b/CalendarPicker/__tests__/__snapshots__/CalendarPicker-test.js.snap
@@ -1866,7 +1866,6 @@ exports[`CalendarPicker It handle selectedStartDate and selectedEndDate props 1`
             style={
               Object {
                 "alignSelf": "center",
-                "backgroundColor": "#CCCCCC",
                 "borderRadius": 60,
                 "height": 60,
                 "justifyContent": "center",
@@ -1890,9 +1889,7 @@ exports[`CalendarPicker It handle selectedStartDate and selectedEndDate props 1`
                   },
                   undefined,
                   undefined,
-                  Object {
-                    "color": "#000000",
-                  },
+                  Object {},
                 ]
               }
             >


### PR DESCRIPTION
The last time the tests were fixed was in February 2019 in pull request #144, which is why the initialDate of new Date(2019, 1, 20) was chosen.

If the initialDate is not chosen, the date defaults to today, which is not stable over time for these tests.