### PR TITLE
Travis: Updated the Linux distribution to Xenial and updated the Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
+dist: xenial
 language: node_js
 node_js:
-  - 6
-  - 7
+  - "lts/*"
+  - "node"


### PR DESCRIPTION
Updated the Linux distribution for the Travis tests to be Xenial, to pick up more recent versions of Node.js by default.

Both Node.js 6 and 7 are no longer supported/maintained by the Node.js project, so also specified the currently active Node.js LTS version (10) and the latest stable Node.js version (12).

See https://github.com/nodejs/Release and https://nodejs.org/en/about/releases/

See https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions for some minimal information on how this is specified in the .travis.yml file.