### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ If you need the old code I saved it on a branch <a href="https://github.com/step
 
 CalendarPicker requires Moment JS.  Date props may be anything parseable by Moment: Javascript Date, Moment date, or ISO8601 datetime string.
 
+```
+npm install --save moment
+```
+
 # Example
 
 ```js


### PR DESCRIPTION
Got this error without installing.

```
Unable to resolve "moment" from "node_modules/react-native-calendar-picker/CalendarPicker/index.js"
Failed building JavaScript bundle.
```