### PR TITLE
Adds accessibilityRole to calendar title for 508 compliance

### DIFF
--- a/CalendarPicker/EmptyDay.js
+++ b/CalendarPicker/EmptyDay.js
@@ -1,29 +1,16 @@
 import React from 'react';
-import {
-  View,
-  Text,
-  TouchableOpacity
-} from 'react-native';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
 
-export default function Day(props) {
+export default function EmptyDay(props) {
   const { styles } = props;
   return(
     <View style={styles.dayWrapper}>
-      <View style={styles.dayButton}>
-        <TouchableOpacity
-          style={styles.dayButton}
-        >
-          <Text style={styles.dayLabel}>
-          </Text>
-        </TouchableOpacity>
-      </View>
+      <View style={styles.dayButton} />
     </View>
   );
 }
 
-Day.propTypes = {
-  styles: PropTypes.shape({}),
-  day: PropTypes.number,
-  onPressDay: PropTypes.func,
+EmptyDay.propTypes = {
+  styles: PropTypes.shape({})
 }

--- a/CalendarPicker/HeaderControls.js
+++ b/CalendarPicker/HeaderControls.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   View,
   Text,
+  Platform
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { Utils } from './Utils';
@@ -18,6 +19,7 @@ export default function HeaderControls(props) {
     previousTitle,
     nextTitle,
     textStyle,
+    headingLevel
   } = props;
   const MONTHS = months? months : Utils.MONTHS; // English Month Array
   // getMonth() call below will return the month number, we will use it as the
@@ -26,6 +28,11 @@ export default function HeaderControls(props) {
   const next = nextTitle ? nextTitle : 'Next';
   const month = MONTHS[currentMonth];
   const year = currentYear;
+
+  const accessibilityProps = { accessibilityRole: 'header' };
+  if (Platform.OS === 'web') {
+    accessibilityProps['aria-level'] = headingLevel;
+  }
 
   return (
     <View style={styles.headerWrapper}>
@@ -36,7 +43,7 @@ export default function HeaderControls(props) {
         textStyles={textStyle}
       />
       <View>
-        <Text style={[styles.monthLabel, textStyle]}>
+        <Text style={[styles.monthLabel, textStyle]} {...accessibilityProps}>
            { month } { year }
         </Text>
       </View>

--- a/CalendarPicker/__tests__/__snapshots__/CalendarPicker-test.js.snap
+++ b/CalendarPicker/__tests__/__snapshots__/CalendarPicker-test.js.snap
@@ -335,48 +335,7 @@ exports[`CalendarPicker It handle selectedStartDate and selectedEndDate props 1`
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -399,48 +358,7 @@ exports[`CalendarPicker It handle selectedStartDate and selectedEndDate props 1`
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -463,48 +381,7 @@ exports[`CalendarPicker It handle selectedStartDate and selectedEndDate props 1`
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -527,48 +404,7 @@ exports[`CalendarPicker It handle selectedStartDate and selectedEndDate props 1`
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -591,48 +427,7 @@ exports[`CalendarPicker It handle selectedStartDate and selectedEndDate props 1`
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -2750,48 +2545,7 @@ exports[`CalendarPicker It renders calendar picker 1`] = `
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -2814,48 +2568,7 @@ exports[`CalendarPicker It renders calendar picker 1`] = `
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -2878,48 +2591,7 @@ exports[`CalendarPicker It renders calendar picker 1`] = `
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -2942,48 +2614,7 @@ exports[`CalendarPicker It renders calendar picker 1`] = `
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -3006,48 +2637,7 @@ exports[`CalendarPicker It renders calendar picker 1`] = `
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -5352,48 +4942,7 @@ exports[`CalendarPicker It renders calendar picker with props 1`] = `
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -5416,48 +4965,7 @@ exports[`CalendarPicker It renders calendar picker with props 1`] = `
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -5480,48 +4988,7 @@ exports[`CalendarPicker It renders calendar picker with props 1`] = `
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={
@@ -5544,48 +5011,7 @@ exports[`CalendarPicker It renders calendar picker with props 1`] = `
                 "width": 60,
               }
             }
-          >
-            <View
-              accessibilityComponentType={undefined}
-              accessibilityLabel={undefined}
-              accessibilityTraits={undefined}
-              accessible={true}
-              hitSlop={undefined}
-              isTVSelectable={true}
-              onLayout={undefined}
-              onResponderGrant={[Function]}
-              onResponderMove={[Function]}
-              onResponderRelease={[Function]}
-              onResponderTerminate={[Function]}
-              onResponderTerminationRequest={[Function]}
-              onStartShouldSetResponder={[Function]}
-              style={
-                Object {
-                  "alignSelf": "center",
-                  "borderRadius": 60,
-                  "height": 60,
-                  "justifyContent": "center",
-                  "opacity": 1,
-                  "width": 60,
-                }
-              }
-              testID={undefined}
-              tvParallaxProperties={undefined}
-            >
-              <Text
-                accessible={true}
-                allowFontScaling={true}
-                ellipsizeMode="tail"
-                style={
-                  Object {
-                    "alignSelf": "center",
-                    "color": "#000",
-                    "fontSize": 28,
-                  }
-                }
-              />
-            </View>
-          </View>
+          />
         </View>
         <View
           style={

--- a/CalendarPicker/__tests__/__snapshots__/CalendarPicker-test.js.snap
+++ b/CalendarPicker/__tests__/__snapshots__/CalendarPicker-test.js.snap
@@ -89,6 +89,7 @@ exports[`CalendarPicker It handle selectedStartDate and selectedEndDate props 1`
       </View>
       <View>
         <Text
+          accessibilityRole="header"
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
@@ -2503,6 +2504,7 @@ exports[`CalendarPicker It renders calendar picker 1`] = `
       </View>
       <View>
         <Text
+          accessibilityRole="header"
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
@@ -5104,6 +5106,7 @@ exports[`CalendarPicker It renders calendar picker with props 1`] = `
       </View>
       <View>
         <Text
+          accessibilityRole="header"
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -44,7 +44,8 @@ export default class CalendarPicker extends Component {
     onDateChange: () => {
       console.log("onDateChange() not provided");
     },
-    enableDateChange: true
+    enableDateChange: true,
+    headingLevel: 1
   };
 
   componentDidUpdate(prevProps, prevState) {
@@ -260,7 +261,8 @@ export default class CalendarPicker extends Component {
       maxRangeDuration,
       swipeConfig,
       customDatesStyles,
-      enableDateChange
+      enableDateChange,
+      headingLevel
     } = this.props;
 
     let _disabledDates = [];
@@ -330,6 +332,7 @@ export default class CalendarPicker extends Component {
             previousTitle={previousTitle}
             nextTitle={nextTitle}
             textStyle={textStyle}
+            headingLevel={headingLevel}
           />
           <Weekdays
             styles={styles}

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ const styles = StyleSheet.create({
 | **`onMonthChange`** | `Function` | Optional. Callback when Previous / Next month is pressed. Returns Moment `date` as first parameter.|
 | **`onSwipe`** | `Function` | Optional. Callback when swipe event is triggered. Returns swipe direction as first parameter.|
 | **`dayShape`** | `String` | Optional. Shape of the Day component. Default is `circle`. Available options are `circle` and `square`.|
+| **`headingLevel`** | `Number` | Optional. Sets the aria-level for the calendar title heading when on Web. Default is `true`.|
 
 # Styles
 Some styles will overwrite some won't. For instance:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ const styles = StyleSheet.create({
 | **`onMonthChange`** | `Function` | Optional. Callback when Previous / Next month is pressed. Returns Moment `date` as first parameter.|
 | **`onSwipe`** | `Function` | Optional. Callback when swipe event is triggered. Returns swipe direction as first parameter.|
 | **`dayShape`** | `String` | Optional. Shape of the Day component. Default is `circle`. Available options are `circle` and `square`.|
-| **`headingLevel`** | `Number` | Optional. Sets the aria-level for the calendar title heading when on Web. Default is `true`.|
+| **`headingLevel`** | `Number` | Optional. Sets the aria-level for the calendar title heading when on Web. Default is `1`.|
 
 # Styles
 Some styles will overwrite some won't. For instance:


### PR DESCRIPTION
We are using CalendarPicker for a cross-platform (iOS, Android, and Web) application within the federal government.  There are strict accessibility requirements which are tested.  For this component, we simply needed to add an accessibilityRole of `heading` for the month/year title of the calendar, and for web include an optional `headingLevel` prop.  The optional prop has no bearing unless the component is being used with react-native-web.

I also discovered that the `EmptyDay` component was using a touchable making the empty spaces "accessible", these were changed to not be accessible.

Thanks for this great and easy to use component!