### PR TITLE
Add option to customize HeaderControls

### DIFF
--- a/CalendarPicker/Controls.js
+++ b/CalendarPicker/Controls.js
@@ -1,24 +1,36 @@
 import React from 'react';
-import {
-  TouchableOpacity,
-  Text,
-} from 'react-native';
+import { TouchableOpacity, Text } from 'react-native';
 import PropTypes from 'prop-types';
 
-export default function Controls({ styles, textStyles, label, onPressControl }) {
+export default function Controls({
+  styles,
+  children,
+  onPressControl,
+  label,
+  textStyles
+}) {
+  if (children) {
+    return (
+      <TouchableOpacity style={styles} onPress={() => onPressControl()}>
+        {children}
+      </TouchableOpacity>
+    );
+  }
   return (
-    <TouchableOpacity
-      onPress={() => onPressControl()}
-    >
-      <Text style={[styles, textStyles]}>
-        { label }
-      </Text>
+    <TouchableOpacity onPress={() => onPressControl()}>
+      <Text style={[styles, textStyles]}>{label}</Text>
     </TouchableOpacity>
   );
 }
 
 Controls.propTypes = {
   styles: PropTypes.array.isRequired,
-  label: PropTypes.string.isRequired,
+  children: PropTypes.any,
   onPressControl: PropTypes.func.isRequired,
+  label: PropTypes.string
+};
+
+Controls.defaultProps = {
+  children: null,
+  label: ''
 };

--- a/CalendarPicker/HeaderControls.js
+++ b/CalendarPicker/HeaderControls.js
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  View,
-  Text,
-} from 'react-native';
+import { View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 import { Utils } from './Utils';
 import Controls from './Controls';
@@ -18,8 +15,12 @@ export default function HeaderControls(props) {
     previousTitle,
     nextTitle,
     textStyle,
+    prevCustomStyle,
+    nextCustomStyle,
+    prevCustomChild,
+    nextCustomChild
   } = props;
-  const MONTHS = months? months : Utils.MONTHS; // English Month Array
+  const MONTHS = months ? months : Utils.MONTHS; // English Month Array
   // getMonth() call below will return the month number, we will use it as the
   // index for month array in english
   const previous = previousTitle ? previousTitle : 'Previous';
@@ -28,24 +29,46 @@ export default function HeaderControls(props) {
   const year = currentYear;
 
   return (
-    <View style={styles.headerWrapper}>
-      <Controls
-        label={previous}
-        onPressControl={onPressPrevious}
-        styles={[styles.monthSelector, styles.prev]}
-        textStyles={textStyle}
-      />
+    <View
+      style={[
+        styles.defaultWrapper,
+        prevCustomChild && nextCustomChild ? styles.childrenWrapper : null
+      ]}
+    >
+      {prevCustomChild ? (
+        <Controls
+          children={prevCustomChild}
+          onPressControl={onPressPrevious}
+          styles={[styles.prevChild, styles.monthSelector, prevCustomStyle]}
+        />
+      ) : (
+        <Controls
+          label={previous}
+          onPressControl={onPressPrevious}
+          styles={[styles.textSelector, styles.prevText]}
+          textStyles={textStyle}
+        />
+      )}
+
       <View>
         <Text style={[styles.monthLabel, textStyle]}>
-           { month } { year }
+          {month} {year}
         </Text>
       </View>
-      <Controls
-        label={next}
-        onPressControl={onPressNext}
-        styles={[styles.monthSelector, styles.next]}
-        textStyles={textStyle}
-      />
+      {nextCustomChild ? (
+        <Controls
+          children={nextCustomChild}
+          onPressControl={onPressNext}
+          styles={[styles.nextChild, styles.monthSelector, nextCustomStyle]}
+        />
+      ) : (
+        <Controls
+          label={next}
+          onPressControl={onPressNext}
+          styles={[styles.textSelector, styles.nextText]}
+          textStyles={textStyle}
+        />
+      )}
     </View>
   );
 }
@@ -55,4 +78,18 @@ HeaderControls.propTypes = {
   currentYear: PropTypes.number,
   onPressNext: PropTypes.func,
   onPressPrevious: PropTypes.func,
+  prevCustomStyle: PropTypes.object,
+  nextCustomStyle: PropTypes.object,
+  prevCustomChild: PropTypes.any,
+  nextCustomChild: PropTypes.any
+};
+HeaderControls.defaultProps = {
+  currentMonth: undefined,
+  currentYear: undefined,
+  onPressNext: () => {},
+  onPressPrevious: () => {},
+  prevCustomStyle: {},
+  nextCustomStyle: {},
+  prevCustomChild: null,
+  nextCustomChild: null
 };

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -1,15 +1,15 @@
-import React, { Component } from "react";
-import { View, Text, Dimensions, StyleSheet } from "react-native";
-import { makeStyles } from "./makeStyles";
-import { Utils } from "./Utils";
-import HeaderControls from "./HeaderControls";
-import Weekdays from "./Weekdays";
-import DaysGridView from "./DaysGridView";
-import Swiper from "./Swiper";
-import moment from "moment";
+import React, { Component } from 'react';
+import { View, Dimensions } from 'react-native';
+import moment from 'moment';
+import { makeStyles } from './makeStyles';
+import { Utils } from './Utils';
+import HeaderControls from './HeaderControls';
+import Weekdays from './Weekdays';
+import DaysGridView from './DaysGridView';
+import Swiper from './Swiper';
 
-const SWIPE_LEFT = "SWIPE_LEFT";
-const SWIPE_RIGHT = "SWIPE_RIGHT";
+const SWIPE_LEFT = 'SWIPE_LEFT';
+const SWIPE_RIGHT = 'SWIPE_RIGHT';
 
 const _swipeConfig = {
   velocityThreshold: 0.3,
@@ -42,7 +42,7 @@ export default class CalendarPicker extends Component {
     scaleFactor: 375,
     enableSwipe: true,
     onDateChange: () => {
-      console.log("onDateChange() not provided");
+      console.log('onDateChange() not provided');
     },
     enableDateChange: true
   };
@@ -60,7 +60,7 @@ export default class CalendarPicker extends Component {
     }
 
     let newMonthYear = {};
-    if (!moment(prevProps.initialDate).isSame(this.props.initialDate, "day")) {
+    if (!moment(prevProps.initialDate).isSame(this.props.initialDate, 'day')) {
       newMonthYear = this.updateMonthYear(this.props.initialDate);
       doStateUpdate = true;
     }
@@ -70,12 +70,12 @@ export default class CalendarPicker extends Component {
       (this.props.selectedStartDate &&
         !moment(prevState.selectedStartDate).isSame(
           this.props.selectedStartDate,
-          "day"
+          'day'
         )) ||
       (this.props.selectedEndDate &&
         !moment(prevState.selectedEndDate).isSame(
           this.props.selectedEndDate,
-          "day"
+          'day'
         ))
     ) {
       const { selectedStartDate = null, selectedEndDate = null } = this.props;
@@ -103,8 +103,8 @@ export default class CalendarPicker extends Component {
     } = props;
 
     // The styles in makeStyles are intially scaled to this width
-    const containerWidth = width ? width : Dimensions.get("window").width;
-    const containerHeight = height ? height : Dimensions.get("window").height;
+    const containerWidth = width ? width : Dimensions.get('window').width;
+    const containerHeight = height ? height : Dimensions.get('window').height;
     const initialScale =
       Math.min(containerWidth, containerHeight) / scaleFactor;
     return {
@@ -209,17 +209,17 @@ export default class CalendarPicker extends Component {
   }
 
   onSwipe(gestureName) {
-    if (typeof this.props.onSwipe === "function") {
+    if (typeof this.props.onSwipe === 'function') {
       this.props.onSwipe(gestureName);
       return;
     }
     switch (gestureName) {
-      case SWIPE_LEFT:
-        this.handleOnPressNext();
-        break;
-      case SWIPE_RIGHT:
-        this.handleOnPressPrevious();
-        break;
+    case SWIPE_LEFT:
+      this.handleOnPressNext();
+      break;
+    case SWIPE_RIGHT:
+      this.handleOnPressPrevious();
+      break;
     }
   }
 
@@ -249,6 +249,10 @@ export default class CalendarPicker extends Component {
       months,
       previousTitle,
       nextTitle,
+      nextCustomChild,
+      prevCustomChild,
+      prevCustomStyle,
+      nextCustomStyle,
       textStyle,
       todayTextStyle,
       selectedDayStyle,
@@ -273,8 +277,7 @@ export default class CalendarPicker extends Component {
           thisDate.set({ hour: 0, minute: 0, second: 0, millisecond: 0 });
           _disabledDates.push(thisDate.valueOf());
         });
-      }
-      else if (disabledDates instanceof Function) {
+      } else if (disabledDates instanceof Function) {
         _disabledDates = disabledDates;
       }
     }
@@ -330,6 +333,10 @@ export default class CalendarPicker extends Component {
             previousTitle={previousTitle}
             nextTitle={nextTitle}
             textStyle={textStyle}
+            nextCustomChild={nextCustomChild}
+            prevCustomChild={prevCustomChild}
+            prevCustomStyle={prevCustomStyle}
+            nextCustomStyle={nextCustomStyle}
           />
           <Weekdays
             styles={styles}

--- a/CalendarPicker/makeStyles.js
+++ b/CalendarPicker/makeStyles.js
@@ -12,45 +12,57 @@ function getBorderRadiusByShape(scaler, dayShape) {
   if (dayShape === 'square') {
     return 0;
   } else {
-    return 30*scaler;
+    return 30 * scaler;
   }
 }
 
-export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundColor, dayShape) {
-  const SELECTED_BG_COLOR = backgroundColor ? backgroundColor : DEFAULT_SELECTED_BACKGROUND_COLOR;
-  const SELECTED_TEXT_COLOR = textColor ? textColor : DEFAULT_SELECTED_TEXT_COLOR;
-  const TODAY_BG_COLOR = todayBackgroundColor ? todayBackgroundColor : DEFAULT_TODAY_BACKGROUND_COLOR;
+export function makeStyles(
+  scaler,
+  backgroundColor,
+  textColor,
+  todayBackgroundColor,
+  dayShape
+) {
+  const SELECTED_BG_COLOR = backgroundColor
+    ? backgroundColor
+    : DEFAULT_SELECTED_BACKGROUND_COLOR;
+  const SELECTED_TEXT_COLOR = textColor
+    ? textColor
+    : DEFAULT_SELECTED_TEXT_COLOR;
+  const TODAY_BG_COLOR = todayBackgroundColor
+    ? todayBackgroundColor
+    : DEFAULT_TODAY_BACKGROUND_COLOR;
 
   return {
     calendar: {
-      height: 320*scaler,
-      marginTop: 10*scaler
+      height: 320 * scaler,
+      marginTop: 10 * scaler
     },
 
     dayButton: {
-      width: 30*scaler,
-      height: 30*scaler,
+      width: 30 * scaler,
+      height: 30 * scaler,
       borderRadius: getBorderRadiusByShape(scaler, dayShape),
       alignSelf: 'center',
       justifyContent: 'center'
     },
 
     dayLabel: {
-      fontSize: 14*scaler,
+      fontSize: 14 * scaler,
       color: '#000',
       alignSelf: 'center'
     },
 
     selectedDayLabel: {
-      color: SELECTED_TEXT_COLOR,
+      color: SELECTED_TEXT_COLOR
     },
 
     dayLabelsWrapper: {
       flexDirection: 'row',
       borderBottomWidth: 1,
       borderTopWidth: 1,
-      paddingTop: 10*scaler,
-      paddingBottom: 10*scaler,
+      paddingTop: 10 * scaler,
+      paddingBottom: 10 * scaler,
       alignSelf: 'center',
       justifyContent: 'center',
       backgroundColor: 'rgba(0,0,0,0.0)',
@@ -63,27 +75,27 @@ export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundCo
     },
 
     dayLabels: {
-      width: 50*scaler,
-      fontSize: 12*scaler,
+      width: 50 * scaler,
+      fontSize: 12 * scaler,
       color: '#000',
       textAlign: 'center'
     },
 
     selectedDay: {
-      width: 30*scaler,
-      height:30*scaler,
+      width: 30 * scaler,
+      height: 30 * scaler,
       borderRadius: getBorderRadiusByShape(scaler, dayShape),
       alignSelf: 'center',
       justifyContent: 'center'
     },
 
     selectedDayBackground: {
-      backgroundColor: SELECTED_BG_COLOR,
+      backgroundColor: SELECTED_BG_COLOR
     },
 
     selectedToday: {
-      width: 30*scaler,
-      height:30*scaler,
+      width: 30 * scaler,
+      height: 30 * scaler,
       backgroundColor: TODAY_BG_COLOR,
       borderRadius: getBorderRadiusByShape(scaler, dayShape),
       alignSelf: 'center',
@@ -93,72 +105,91 @@ export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundCo
     dayWrapper: {
       alignItems: 'center',
       justifyContent: 'center',
-      width: 50*scaler,
-      height: 40*scaler,
+      width: 50 * scaler,
+      height: 40 * scaler,
       backgroundColor: 'rgba(0,0,0,0.0)'
     },
 
     startDayWrapper: {
-      width: 50*scaler,
-      height: 30*scaler,
-      borderTopLeftRadius: 20*scaler,
-      borderBottomLeftRadius: 20*scaler,
+      width: 50 * scaler,
+      height: 30 * scaler,
+      borderTopLeftRadius: 20 * scaler,
+      borderBottomLeftRadius: 20 * scaler,
       backgroundColor: SELECTED_BG_COLOR,
       alignSelf: 'center',
       justifyContent: 'center'
     },
 
     endDayWrapper: {
-      width: 50*scaler,
-      height: 30*scaler,
-      borderTopRightRadius: 20*scaler,
-      borderBottomRightRadius: 20*scaler,
+      width: 50 * scaler,
+      height: 30 * scaler,
+      borderTopRightRadius: 20 * scaler,
+      borderBottomRightRadius: 20 * scaler,
       backgroundColor: SELECTED_BG_COLOR,
       alignSelf: 'center',
       justifyContent: 'center'
     },
 
     inRangeDay: {
-      width: 50*scaler,
-      height: 30*scaler,
+      width: 50 * scaler,
+      height: 30 * scaler,
       backgroundColor: SELECTED_BG_COLOR,
       alignSelf: 'center',
       justifyContent: 'center'
     },
 
     monthLabel: {
-      fontSize: 16*scaler,
+      fontSize: 16 * scaler,
       color: '#000',
-      marginBottom: 10*scaler,
-      width: 180*scaler,
+      marginBottom: 10 * scaler,
+      width: 180 * scaler,
       textAlign: 'center'
     },
 
-    headerWrapper: {
+    childrenWrapper: {
+      position: 'relative',
+      width: '94%'
+    },
+
+    defaultWrapper: {
       alignItems: 'center',
       flexDirection: 'row',
       alignSelf: 'center',
-      padding: 5*scaler,
-      paddingBottom: 3*scaler,
+      justifyContent: 'center',
+      padding: 5 * scaler,
+      paddingBottom: 3 * scaler,
       backgroundColor: 'rgba(0,0,0,0.0)'
     },
 
     monthSelector: {
-      marginBottom: 10*scaler,
-      fontSize: 14*scaler,
-      width: 80*scaler
+      position: 'absolute',
+      top: 0
     },
 
-    prev: {
+    prevChild: {
+      left: 0
+    },
+
+    nextChild: {
+      right: 0
+    },
+
+    prevText: {
       textAlign: 'left'
     },
 
-    next: {
+    nextText: {
       textAlign: 'right'
     },
 
+    textSelector: {
+      marginBottom: 10 * scaler,
+      fontSize: 14 * scaler,
+      width: 80 * scaler
+    },
+
     yearLabel: {
-      fontSize: 14*scaler,
+      fontSize: 14 * scaler,
       fontWeight: 'bold',
       color: '#000',
       textAlign: 'center'
@@ -173,7 +204,7 @@ export function makeStyles(scaler, backgroundColor, textColor, todayBackgroundCo
     },
 
     disabledText: {
-      fontSize: 14*scaler,
+      fontSize: 14 * scaler,
       color: '#BBBBBB',
       alignSelf: 'center',
       justifyContent: 'center'

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ const styles = StyleSheet.create({
 | **`allowRangeSelection`** | `Boolean` | Optional. Allow to select date ranges. Default is `false` |
 | **`previousTitle`** | `String` | Optional. Title of button for previous month. Default is `Previous` |
 | **`nextTitle`** | `String` | Optional. Title of button for next month. Default is `Next` |
+| **`prevCustomChild`** | `Any` | Optional. Replaces previousTitle with your own custom component (to be used along with prevCustomChild) |
+| **`nextCustomChild`** | `Any` | Optional. Replaces nextTitle with your own custom component (to be used along with nextCustomChild) |
+| **`prevCustomStyle`** | `Object` | Optional. Custom style wrapper for prevCustomChild |
+| **`nextCustomStyle`** | `Object` | Optional. Custom style wrapper for nextCustomChild |
 | **`selectedDayColor`** | `String` | Optional. Color for selected day |
 | **`selectedDayStyle`** | `ViewStyle` | Optional. Style for selected day. May override selectedDayColor.|
 | **`selectedDayTextColor`** | `String` | Optional. Text color for selected day |
@@ -308,6 +312,27 @@ render() {
       minDate={today}
     />
   );
+}
+```
+
+
+### Custom styling controls
+
+![alt tag](https://i.imgur.com/AkESq3H.png)
+
+```js
+render() {
+    <CalendarPicker
+      allowRangeSelection
+      //custom children components (<View> or <Image> or <Icon> or <Text> etc)
+      prevCustomChild={<ArrowLeft svgColor="green" svgWidth="24" svgHeight="24" />}
+      nextCustomChild={<ArrowRight svgColor="red" svgWidth="24" svgHeight="24" />}
+      prevCustomStyle={{ padding: 5 }} // controls the wrapper of prevCustomChild
+      nextCustomStyle={{ padding: 5 }} // controls the wrapper of nextCustomChild
+      todayBackgroundColor="blue"
+      selectedDayColor="red"
+      selectedDayTextColor="#fff"
+    />
 }
 ```
 


### PR DESCRIPTION
Hi!

By default, it will render the texts provided in nextTitle, previousTitle.

Optional props added:
```
      prevCustomChild={Any}
      nextCustomChild={Any}
      prevCustomStyle={Object} // controls the wrapper of prevCustomChild
      nextCustomStyle={Object} // controls the wrapper of nextCustomChild
```
If children are provided, CalendarPicker will render them inside <Controls />

Updated Readme table and added a new example with custom icons.

Sample:
![image](https://user-images.githubusercontent.com/9382283/67569459-a2512680-f737-11e9-8ec3-96c1309fe647.png)

