### PR TITLE
Specify moment.js dependency version more accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you need the old code I saved it on a branch <a href="https://github.com/step
 
 # Prerequisites
 
-CalendarPicker requires Moment JS.  Date props may be anything parseable by Moment: Javascript Date, Moment date, or ISO8601 datetime string.
+CalendarPicker requires Moment JS >=2.0.  Date props may be anything parseable by Moment: Javascript Date, Moment date, or ISO8601 datetime string.
 
 ```
 npm install --save moment

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=4.0.0"
   },
   "peerDependencies": {
-    "moment": "*",
+    "moment": ">=2.0.0",
     "react": "*",
     "react-native": "*"
   },


### PR DESCRIPTION
Specify moment.js peerDep versions more accurately. This package uses moment.js APIs like `isAfter()` or `isSame()` which were introduced in version 2.0.0, so using this package with a lower moment.js version would not work. 