### PR TITLE
dayOfWeekStyles should apply When calendar start and customDatesStyle…

### DIFF
--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -54,7 +54,7 @@ export default class CalendarPicker extends Component {
   };
 
   componentDidMount() {
-    this.updateDayOfWeekStyles(moment());
+    this.updateDayOfWeekStyles(this.props.initialDate ? moment(this.props.initialDate) : moment());
   }
 
   updateDayOfWeekStyles = currentDate => {
@@ -324,7 +324,7 @@ export default class CalendarPicker extends Component {
     let tempCustomDatesStyles = customDatesStyles;
     if (Object.entries(dayOfWeekStyles).length > 0) {
       tempCustomDatesStyles = customDatesStyles
-        ? customDatesStyles
+        ? customDatesStyles.concat(defaultCustomDatesStyles)
         : defaultCustomDatesStyles;
     }
     if (disabledDates) {

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ const styles = StyleSheet.create({
 | **`todayTextStyle`** | `TextStyle` | Optional. Text styling for today. |
 | **`textStyle`** | `TextStyle` | Optional. Style overall text. Change fontFamily, color, etc. |
 | **`customDatesStyles`** | `Array` | Optional. Style individual date(s). Array of objects `{date: Moment-parseable date, containerStyle: ViewStyle, style: ViewStyle, textStyle: TextStyle}` |
+| **`customDatesStylesPriority`** | `String` | Optional. Precedence of `customDates` or `dayOfWeek` styles. Default `dayOfWeek` |
 | **`scaleFactor`** | `Number` | Optional. Default (375) scales to window width |
 | **`minDate`** | `Date` | Optional. Specifies minimum date to be selected |
 | **`maxDate`** | `Date` | Optional. Specifies maximum date to be selected |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-calendar-picker",
-  "version": "6.0.7",
+  "version": "6.0.6",
   "description": "Calendar Picker Component for React Native",
   "engines": {
     "node": ">=4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-calendar-picker",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "Calendar Picker Component for React Native",
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
1. CalendarPicker allow to set both dayOfWeekStyles and customDatesStyles. But customDatesStyles has precedence and both properties can not work together. I think, caller should have the control and CalendarPicker should take care of both dayOfWeekStyles and customDatesStyles.

2. CalendarPicker allow to set initialDate and it help to initiate calendar with any arbitary date and it is good. But it does not apply dayOfWeekStyles when initiate.

This request has solution to above both cases.