### PR TITLE
Add reverse range selection functionality

### DIFF
--- a/CalendarPicker/Day.js
+++ b/CalendarPicker/Day.js
@@ -18,6 +18,7 @@ export default function Day(props) {
     selectedStartDate,
     selectedEndDate,
     allowRangeSelection,
+    allowBackwardRangeSelect,
     selectedDayStyle,
     selectedRangeStartStyle,
     selectedRangeStyle,
@@ -77,7 +78,13 @@ export default function Day(props) {
     }
   }
 
-	if (allowRangeSelection && maxRangeDuration && selectedStartDate && thisDay.isAfter(moment(selectedStartDate), 'day') ) {
+  if (
+    allowRangeSelection &&
+    maxRangeDuration &&
+    selectedStartDate &&
+    thisDay.isAfter(moment(selectedStartDate), 'day') &&
+    (!selectedEndDate || !allowBackwardRangeSelect)
+  ) {
 		if (Array.isArray(maxRangeDuration)) {
 			let i = maxRangeDuration.findIndex(i => moment(i.date).isSame(moment(selectedStartDate), 'day') );
 			if (i >= 0 && moment(selectedStartDate).add(maxRangeDuration[i].maxDuration, 'day').isBefore(thisDay, 'day') ) {

--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -23,6 +23,7 @@ export default function DaysGridView(props) {
     selectedStartDate,
     selectedEndDate,
     allowRangeSelection,
+    allowBackwardRangeSelect,
     textStyle,
     todayTextStyle,
     selectedDayStyle,
@@ -82,6 +83,7 @@ export default function DaysGridView(props) {
                 selectedStartDate={selectedStartDate}
                 selectedEndDate={selectedEndDate}
                 allowRangeSelection={allowRangeSelection}
+                allowBackwardRangeSelect={allowBackwardRangeSelect}
                 minDate={minDate}
                 maxDate={maxDate}
                 disabledDates={disabledDates}
@@ -121,6 +123,7 @@ export default function DaysGridView(props) {
               selectedStartDate={selectedStartDate}
               selectedEndDate={selectedEndDate}
               allowRangeSelection={allowRangeSelection}
+              allowBackwardRangeSelect={allowBackwardRangeSelect}
               minDate={minDate}
               maxDate={maxDate}
               disabledDates={disabledDates}

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -172,7 +172,12 @@ export default class CalendarPicker extends Component {
       selectedEndDate
     } = this.state;
 
-    const { allowRangeSelection, onDateChange, enableDateChange } = this.props;
+    const {
+      allowRangeSelection,
+      onDateChange,
+      enableDateChange,
+      allowBackwardRangeSelect,
+    } = this.props;
 
     if (!enableDateChange) {
       return;
@@ -180,15 +185,17 @@ export default class CalendarPicker extends Component {
 
     const date = moment({ year: currentYear, month: currentMonth, day, hour: 12 });
 
-    if (
-      allowRangeSelection &&
-      selectedStartDate &&
-      date.isSameOrAfter(selectedStartDate, "day") &&
-      !selectedEndDate
-    ) {
-      this.setState({
-        selectedEndDate: date
-      });
+    if (allowRangeSelection && selectedStartDate && !selectedEndDate) {
+      if (date.isSameOrAfter(selectedStartDate, "day")) {
+        this.setState({
+          selectedEndDate: date
+        });
+      } else if (allowBackwardRangeSelect) {
+        this.setState({
+          selectedStartDate: date,
+          selectedEndDate: selectedStartDate,
+        });
+      }
       // propagate to parent date has changed
       onDateChange(date, Utils.END_DATE);
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-calendar-picker",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "Calendar Picker Component for React Native",
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
- Add prop: allowBackwardRangeSelect for reverse date range selection.
- Conditional logic for allowBackwardRangeSelect:
  - Add start & end callbacks when both dates are changing
  - Conditionally allow future date range selection if allowBackwardRangeSelect is enabled.
  - Integrate allowBackwardRangeSelect with maxRangeDuration