### PR TITLE
Add prop: allowBackwardRangeSelect for reverse date range selection.

### DIFF
--- a/CalendarPicker/Day.js
+++ b/CalendarPicker/Day.js
@@ -18,6 +18,7 @@ export default function Day(props) {
     selectedStartDate,
     selectedEndDate,
     allowRangeSelection,
+    allowBackwardRangeSelect,
     selectedDayStyle,
     selectedRangeStartStyle,
     selectedRangeStyle,
@@ -77,7 +78,13 @@ export default function Day(props) {
     }
   }
 
-	if (allowRangeSelection && maxRangeDuration && selectedStartDate && thisDay.isAfter(moment(selectedStartDate), 'day') ) {
+  if (
+    allowRangeSelection &&
+    maxRangeDuration &&
+    selectedStartDate &&
+    thisDay.isAfter(moment(selectedStartDate), 'day') &&
+    (!selectedEndDate || !allowBackwardRangeSelect)
+  ) {
 		if (Array.isArray(maxRangeDuration)) {
 			let i = maxRangeDuration.findIndex(i => moment(i.date).isSame(moment(selectedStartDate), 'day') );
 			if (i >= 0 && moment(selectedStartDate).add(maxRangeDuration[i].maxDuration, 'day').isBefore(thisDay, 'day') ) {

--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -23,6 +23,7 @@ export default function DaysGridView(props) {
     selectedStartDate,
     selectedEndDate,
     allowRangeSelection,
+    allowBackwardRangeSelect,
     textStyle,
     todayTextStyle,
     selectedDayStyle,
@@ -82,6 +83,7 @@ export default function DaysGridView(props) {
                 selectedStartDate={selectedStartDate}
                 selectedEndDate={selectedEndDate}
                 allowRangeSelection={allowRangeSelection}
+                allowBackwardRangeSelect={allowBackwardRangeSelect}
                 minDate={minDate}
                 maxDate={maxDate}
                 disabledDates={disabledDates}
@@ -121,6 +123,7 @@ export default function DaysGridView(props) {
               selectedStartDate={selectedStartDate}
               selectedEndDate={selectedEndDate}
               allowRangeSelection={allowRangeSelection}
+              allowBackwardRangeSelect={allowBackwardRangeSelect}
               minDate={minDate}
               maxDate={maxDate}
               disabledDates={disabledDates}

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -172,29 +172,114 @@ export default class CalendarPicker extends Component {
       selectedEndDate
     } = this.state;
 
-    const { allowRangeSelection, onDateChange, enableDateChange } = this.props;
+    const {
+      allowRangeSelection,
+      onDateChange,
+      enableDateChange,
+      allowBackwardRangeSelect,
+      maxRangeDuration,
+    } = this.props;
 
     if (!enableDateChange) {
       return;
     }
 
-    const date = moment({ year: currentYear, month: currentMonth, day, hour: 12 });
+    const date = moment({ year: currentYear, month: currentMonth, day, hour: 12 }),
+      startDate = selectedStartDate && moment(selectedStartDate),
+      endDate = selectedEndDate && moment(selectedEndDate);
 
-    if (
-      allowRangeSelection &&
-      selectedStartDate &&
-      date.isSameOrAfter(selectedStartDate, "day") &&
-      !selectedEndDate
-    ) {
-      this.setState({
-        selectedEndDate: date
-      });
-      // propagate to parent date has changed
-      onDateChange(date, Utils.END_DATE);
+    if (allowRangeSelection && startDate && !endDate) {
+      if (date.isSameOrAfter(startDate, 'day')) {
+        this.setState({
+          selectedEndDate: date,
+        });
+        // propagate to parent date has changed
+        onDateChange(date, Utils.END_DATE);
+        if (
+          maxRangeDuration &&
+          !isNaN(maxRangeDuration) &&
+          date.diff(startDate, 'days') > maxRangeDuration
+        ) {
+          const newStartDate = date.clone().subtract(maxRangeDuration, 'days');
+          this.setState({
+            selectedStartDate: newStartDate,
+          });
+          // propagate to parent date has changed
+          onDateChange(newStartDate, Utils.START_DATE);
+        }
+      } else if (allowBackwardRangeSelect) {
+        if (
+          maxRangeDuration &&
+          !isNaN(maxRangeDuration) &&
+          startDate.diff(date, 'days') > maxRangeDuration
+        ) {
+          const newEndDate = date.clone().add(maxRangeDuration, 'days');
+          this.setState({
+            selectedStartDate: date,
+            selectedEndDate: newEndDate,
+          });
+          // propagate to parent date has changed
+          onDateChange(date, Utils.START_DATE);
+          onDateChange(newEndDate, Utils.END_DATE);
+        } else {
+          this.setState({
+            selectedStartDate: date,
+            selectedEndDate: startDate,
+          });
+          // propagate to parent date has changed
+          onDateChange(date, Utils.START_DATE);
+          onDateChange(startDate, Utils.END_DATE);
+        }
+      } else {
+        this.setState({
+          selectedStartDate: date,
+          selectedEndDate: null,
+        });
+        // propagate to parent date has changed
+        onDateChange(date, Utils.START_DATE);
+      }
+    } else if (allowRangeSelection && startDate) {
+      if (endDate.diff(date, 'days') > maxRangeDuration) {
+        if (date.isBefore(endDate)) {
+          const newEndDate = date.clone().add(maxRangeDuration, 'days');
+          this.setState({
+            selectedStartDate: date,
+            selectedEndDate: newEndDate,
+          });
+          // propagate to parent date has changed
+          onDateChange(date, Utils.START_DATE);
+          onDateChange(newEndDate, Utils.END_DATE);
+        } else if (allowBackwardRangeSelect) {
+          const newStartDate = date.clone().subtract(maxRangeDuration, 'days');
+          this.setState({
+            selectedStartDate: newStartDate,
+            selectedEndDate: date,
+          });
+          // propagate to parent date has changed
+          onDateChange(newStartDate, Utils.START_DATE);
+          onDateChange(date, Utils.END_DATE);
+        } else {
+          this.setState({
+            selectedStartDate: date,
+            selectedEndDate: null,
+          });
+          // propagate to parent date has changed
+          onDateChange(date, Utils.START_DATE);
+          onDateChange(null, Utils.END_DATE);
+        }
+      } else {
+        this.setState({
+          selectedStartDate: date,
+          selectedEndDate: null,
+        });
+        // propagate to parent date has changed
+        onDateChange(date, Utils.START_DATE);
+        onDateChange(null, Utils.END_DATE);
+      }
     } else {
       this.setState({
         selectedStartDate: date,
-        selectedEndDate: null
+        selectedEndDate: null,
       });
       // propagate to parent date has changed
       onDateChange(date, Utils.START_DATE);
@@ -293,6 +378,7 @@ export default class CalendarPicker extends Component {
 
     const {
       allowRangeSelection,
+      allowBackwardRangeSelect,
       startFromMonday,
       initialDate,
       weekdays,
@@ -419,6 +505,7 @@ export default class CalendarPicker extends Component {
             maxRangeDuration={maxRangeDurationTime}
             startFromMonday={startFromMonday}
             allowRangeSelection={allowRangeSelection}
+            allowBackwardRangeSelect={allowBackwardRangeSelect}
             selectedStartDate={selectedStartDate && moment(selectedStartDate)}
             selectedEndDate={selectedEndDate && moment(selectedEndDate)}
             minDate={this.state.minDate}


### PR DESCRIPTION
- Add prop: allowBackwardRangeSelect for reverse date range selection.
- Conditional logic for allowBackwardRangeSelect:
  - Add start & end callbacks when both dates are changing
  - Conditionally allow future date range selection if allowBackwardRangeSelect is enabled.
  - Integrate allowBackwardRangeSelect with maxRangeDuration

@see: https://github.com/stephy/CalendarPicker/issues/171