### PR TITLE
Removes postinstall to work in AWS Amplify

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "start": "echo \"example folder contains sample app (see README)\" && exit 1",
     "test": "echo \"example folder contains the tests (see README)\" && exit 1",
-    "lint": "eslint CalendarPicker --fix",
-    "postinstall": "cpx \".githooks/*\" \".git/hooks\" -u"
+    "lint": "eslint CalendarPicker --fix"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When adding this lib to expo web and deploying it with AWS Amplify, the following error is given:
`/node_modules/react-native-calendar-picker: Appears to be a git repo or submodule.`