### PR TITLE
Trigger onMonthChange in handleOnSelectMonthYear

### DIFF
--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -343,6 +343,8 @@ export default class CalendarPicker extends Component {
       currentView: 'days',
       ...scrollableState,
     });
+    
+    this.handleOnPressFinisher({year, month});
   }
 
   resetSelections = () => {


### PR DESCRIPTION
the onMonthChange prop isn't called in the handleOnSelectMonthYear() so if users make changes by using the the Month and Year selector, it won't return the moment data object as onMonthChange supposed to do. But I reference the handleOnPressFinisher() as the fix to avoid code duplication.