### PR TITLE
fix: use restrictMonthNavigation without defining maxDate & minDate

### DIFF
--- a/CalendarPicker/YearsHeader.js
+++ b/CalendarPicker/YearsHeader.js
@@ -27,8 +27,8 @@ export default function YearsHeader(props) {
     headingLevel,
   } = props;
 
-  const disablePrevious = restrictNavigation && (minDate.year() >= year);
-  const disableNext = restrictNavigation && (maxDate.year() <= year);
+  const disablePrevious = restrictNavigation && minDate && (minDate.year() >= year);
+  const disableNext = restrictNavigation && maxDate && (maxDate.year() <= year);
 
   const accessibilityProps = { accessibilityRole: 'header' };
   if (Platform.OS === 'web') {


### PR DESCRIPTION
Resolves #230 
- Check if maxDate & minDate is defined before checking while using restrictMonthNavigation
