### PR TITLE
fix: replace ViewPropTypes with PropTypes 

### DIFF
--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import {
   View,
   Text,
-  ViewPropTypes as RNViewPropTypes,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import Day from './Day';
@@ -10,7 +9,9 @@ import EmptyDay from './EmptyDay';
 import { Utils } from './Utils';
 import moment from 'moment';
 
-const ViewPropTypes = RNViewPropTypes || View.propTypes;
+const ViewPropTypes = PropTypes.shape({
+  style: PropTypes.any,
+});
 
 export default class DaysGridView extends Component {
   constructor(props) {


### PR DESCRIPTION
Why
--
I've been using this package in Expo and the web build failed because ViewPropTypes is removed in RNW >= 0.12.1

In this PR
--
Replace ViewPropTypes with PropTypes as it has been deprecated in RNW >=0.12.1 https://github.com/necolas/react-native-web/issues/1537#issuecomment-584806182

(Inspired by: https://github.com/ozcanzaferayan/react-native-web-swiper/commit/0ef4ca89d62e59c0ce2cece6dc0edd133d3fd703)