### PR TITLE
Don't allow range of 0 when minRangeDates > 0

### DIFF
--- a/CalendarPicker/Day.js
+++ b/CalendarPicker/Day.js
@@ -20,6 +20,7 @@ export default function Day(props) {
     allowRangeSelection,
     allowBackwardRangeSelect,
     selectedDayStyle,
+    selectedDisabledDatesTextStyle,
     selectedRangeStartStyle,
     selectedRangeStyle,
     selectedRangeEndStyle,
@@ -102,9 +103,13 @@ export default function Day(props) {
 
   let isThisDaySameAsSelectedStart = thisDay.isSame(selectedStartDate, 'day');
   let isThisDaySameAsSelectedEnd = thisDay.isSame(selectedEndDate, 'day');
+  let isThisDateInSelectedRange =
+    selectedStartDate
+    && selectedEndDate
+    && thisDay.isBetween(selectedStartDate, selectedEndDate,'day',"[]");
 
   // If date is in range let's apply styles
-  if (!dateOutOfRange || isThisDaySameAsSelectedStart || isThisDaySameAsSelectedEnd) {
+  if (!dateOutOfRange || isThisDaySameAsSelectedStart || isThisDaySameAsSelectedEnd || isThisDateInSelectedRange) {
     // set today's style
     let isToday = thisDay.isSame(today, 'day');
     if (isToday) {
@@ -184,7 +189,10 @@ export default function Day(props) {
       return (
         <View style={[styles.dayWrapper, customContainerStyle]}>
           <View style={[customDateStyle, daySelectedStyle, propSelectedDayStyle ]}>
-            <Text style={[styles.dayLabel, textStyle, customTextStyle, selectedDayColorStyle]}>
+            <Text style={[styles.dayLabel, textStyle,
+              styles.disabledText, disabledDatesTextStyle,
+              styles.selectedDisabledText, selectedDisabledDatesTextStyle,
+            ]}>
               { day }
             </Text>
           </View>

--- a/CalendarPicker/Day.js
+++ b/CalendarPicker/Day.js
@@ -102,109 +102,110 @@ export default function Day(props) {
 
   let isThisDaySameAsSelectedStart = thisDay.isSame(selectedStartDate, 'day');
   let isThisDaySameAsSelectedEnd = thisDay.isSame(selectedEndDate, 'day');
-  // set today's style
-  let isToday = thisDay.isSame(today, 'day');
-  if (isToday) {
-    daySelectedStyle = styles.selectedToday;
-    // todayTextStyle prop overrides selectedDayTextColor (created via makeStyles)
-    selectedDayColorStyle = todayTextStyle || styles.selectedDayLabel;
-  }
 
-  if (Array.isArray(customDatesStyles)) {
-    for (let cds of customDatesStyles) {
-      if (thisDay.isSame(moment(cds.date), 'day')) {
-        customContainerStyle = cds.containerStyle;
-        customDateStyle = cds.style;
-        customTextStyle = cds.textStyle;
-        break;
+  // If date is in range let's apply styles
+  if (!dateOutOfRange || isThisDaySameAsSelectedStart || isThisDaySameAsSelectedEnd) {
+    // set today's style
+    let isToday = thisDay.isSame(today, 'day');
+    if (isToday) {
+      daySelectedStyle = styles.selectedToday;
+      // todayTextStyle prop overrides selectedDayTextColor (created via makeStyles)
+      selectedDayColorStyle = todayTextStyle || styles.selectedDayLabel;
+    }
+
+    if (Array.isArray(customDatesStyles)) {
+      for (let cds of customDatesStyles) {
+        if (thisDay.isSame(moment(cds.date), 'day')) {
+          customContainerStyle = cds.containerStyle;
+          customDateStyle = cds.style;
+          customTextStyle = cds.textStyle;
+          break;
+        }
       }
     }
-  }
-  else if (customDatesStyles instanceof Function) {
-    let cds = customDatesStyles(thisDay) || {};
-    customContainerStyle = cds.containerStyle;
-    customDateStyle = cds.style;
-    customTextStyle = cds.textStyle;
-  }
-  if (isToday && customDateStyle) {
-    // Custom date style overrides 'today' style. It may be reset below
-    // by date selection styling.
-    daySelectedStyle = [daySelectedStyle, customDateStyle];
-  }
+    else if (customDatesStyles instanceof Function) {
+      let cds = customDatesStyles(thisDay) || {};
+      customContainerStyle = cds.containerStyle;
+      customDateStyle = cds.style;
+      customTextStyle = cds.textStyle;
+    }
+    if (isToday && customDateStyle) {
+      // Custom date style overrides 'today' style. It may be reset below
+      // by date selection styling.
+      daySelectedStyle = [daySelectedStyle, customDateStyle];
+    }
 
-  // set selected day style
-  if (!allowRangeSelection &&
-      selectedStartDate &&
-      isThisDaySameAsSelectedStart) {
-    daySelectedStyle = styles.selectedDay;
-    selectedDayColorStyle = [styles.selectedDayLabel, isToday && todayTextStyle];
-    // selectedDayStyle prop overrides selectedDayColor (created via makeStyles)
-    propSelectedDayStyle = selectedDayStyle || styles.selectedDayBackground;
-  }
+    // set selected day style
+    if (!allowRangeSelection &&
+        selectedStartDate &&
+        isThisDaySameAsSelectedStart) {
+      daySelectedStyle = styles.selectedDay;
+      selectedDayColorStyle = [styles.selectedDayLabel, isToday && todayTextStyle];
+      // selectedDayStyle prop overrides selectedDayColor (created via makeStyles)
+      propSelectedDayStyle = selectedDayStyle || styles.selectedDayBackground;
+    }
 
-  // Set selected ranges styles
-  if (allowRangeSelection) {
-    if (selectedStartDate && selectedEndDate) {
-      // Apply style for start date
-      if (isThisDaySameAsSelectedStart) {
+    // Set selected ranges styles
+    if (allowRangeSelection) {
+      if (selectedStartDate && selectedEndDate) {
+        // Apply style for start date
+        if (isThisDaySameAsSelectedStart) {
+          daySelectedStyle = [styles.startDayWrapper, selectedRangeStyle, selectedRangeStartStyle];
+          selectedDayColorStyle = styles.selectedDayLabel;
+        }
+        // Apply style for end date
+        if (isThisDaySameAsSelectedEnd) {
+          daySelectedStyle = [styles.endDayWrapper, selectedRangeStyle, selectedRangeEndStyle];
+          selectedDayColorStyle = styles.selectedDayLabel;
+        }
+        // Apply style if start date is the same as end date
+        if (isThisDaySameAsSelectedEnd &&
+            isThisDaySameAsSelectedStart &&
+            selectedEndDate.isSame(selectedStartDate, 'day')) {
+          daySelectedStyle = [styles.selectedDay, styles.selectedDayBackground, selectedRangeStyle];
+          selectedDayColorStyle = styles.selectedDayLabel;
+        }
+        // Apply style if this day is in range
+        if (thisDay.isBetween(selectedStartDate, selectedEndDate, 'day')) {
+          daySelectedStyle = [styles.inRangeDay, selectedRangeStyle];
+          selectedDayColorStyle = styles.selectedDayLabel;
+        }
+      }
+      // Apply style if start date has been selected but end date has not
+      if (selectedStartDate &&
+          !selectedEndDate &&
+          isThisDaySameAsSelectedStart) {
         daySelectedStyle = [styles.startDayWrapper, selectedRangeStyle, selectedRangeStartStyle];
         selectedDayColorStyle = styles.selectedDayLabel;
       }
-      // Apply style for end date
-      if (isThisDaySameAsSelectedEnd) {
-        daySelectedStyle = [styles.endDayWrapper, selectedRangeStyle, selectedRangeEndStyle];
-        selectedDayColorStyle = styles.selectedDayLabel;
-      }
-      // Apply style if start date is the same as end date
-      if (isThisDaySameAsSelectedEnd &&
-          isThisDaySameAsSelectedStart &&
-          selectedEndDate.isSame(selectedStartDate, 'day')) {
-        daySelectedStyle = [styles.selectedDay, styles.selectedDayBackground, selectedRangeStyle];
-        selectedDayColorStyle = styles.selectedDayLabel;
-      }
-      // Apply style if this day is in range
-      if (thisDay.isBetween(selectedStartDate, selectedEndDate, 'day')) {
-        daySelectedStyle = [styles.inRangeDay, selectedRangeStyle];
-        selectedDayColorStyle = styles.selectedDayLabel;
-      }
     }
-    // Apply style if start date has been selected but end date has not
-    if (selectedStartDate &&
-        !selectedEndDate &&
-        isThisDaySameAsSelectedStart) {
-      daySelectedStyle = [styles.startDayWrapper, selectedRangeStyle, selectedRangeStartStyle];
-      selectedDayColorStyle = styles.selectedDayLabel;
-    }
-  }
 
-  // If date is in range let's apply styles
-  if (!dateOutOfRange) {
-    return (
-      <View style={[styles.dayWrapper, customContainerStyle]}>
-        <TouchableOpacity
-          disabled={!enableDateChange}
-          style={[customDateStyle, daySelectedStyle, propSelectedDayStyle ]}
-          onPress={() => onPressDay({year, month, day}) }>
-          <Text style={[styles.dayLabel, textStyle, customTextStyle, selectedDayColorStyle]}>
-            { day }
-          </Text>
-        </TouchableOpacity>
-      </View>
-    );
-  }
-  else if (isThisDaySameAsSelectedStart || isThisDaySameAsSelectedEnd) {
-    return (
-      <View style={[styles.dayWrapper, customContainerStyle]}>
-        <View
-          style={[customDateStyle, daySelectedStyle, propSelectedDayStyle ]}>
-          <Text style={[styles.dayLabel, textStyle, customTextStyle, selectedDayColorStyle]}>
-            { day }
-          </Text>
+    if (dateOutOfRange) { // selected start or end date, but not selectable now
+      return (
+        <View style={[styles.dayWrapper, customContainerStyle]}>
+          <View style={[customDateStyle, daySelectedStyle, propSelectedDayStyle ]}>
+            <Text style={[styles.dayLabel, textStyle, customTextStyle, selectedDayColorStyle]}>
+              { day }
+            </Text>
+          </View>
         </View>
-      </View>
-    );
+      );
+    } else {
+      return (
+        <View style={[styles.dayWrapper, customContainerStyle]}>
+          <TouchableOpacity
+            disabled={!enableDateChange}
+            style={[customDateStyle, daySelectedStyle, propSelectedDayStyle ]}
+            onPress={() => onPressDay({year, month, day}) }>
+            <Text style={[styles.dayLabel, textStyle, customTextStyle, selectedDayColorStyle]}>
+              { day }
+            </Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
   }
-  else {  // dateOutOfRange = true
+  else {  // dateOutOfRange = true but not selected start or end date
     return (
       <View style={styles.dayWrapper}>
         <Text style={[textStyle, styles.disabledText, disabledDatesTextStyle]}>

--- a/CalendarPicker/Day.js
+++ b/CalendarPicker/Day.js
@@ -85,10 +85,10 @@ export default function Day(props) {
     if (minRangeDuration) {
       if (Array.isArray(minRangeDuration)) {
         let minRangeEntry = minRangeDuration.find(mrd => selectedStartDate.isSame(mrd.date, 'day') );
-        if (minRangeEntry && daysDiff < minRangeEntry.minDuration && daysDiff !== 0) {
+        if (minRangeEntry && daysDiff < minRangeEntry.minDuration) {
           dateRangeLessThanMin = true;
         }
-      } else if(daysDiff < minRangeDuration && daysDiff !== 0) {
+      } else if(daysDiff < minRangeDuration) {
         dateRangeLessThanMin = true;
       }
     }
@@ -100,86 +100,85 @@ export default function Day(props) {
 
   dateOutOfRange = dateIsAfterMax || dateIsBeforeMin || dateIsDisabled || dateRangeLessThanMin || dateRangeGreaterThanMax;
 
-  // If date is in range let's apply styles
-  if (!dateOutOfRange) {
-    // set today's style
-    let isToday = thisDay.isSame(today, 'day');
-    if (isToday) {
-      daySelectedStyle = styles.selectedToday;
-      // todayTextStyle prop overrides selectedDayTextColor (created via makeStyles)
-      selectedDayColorStyle = todayTextStyle || styles.selectedDayLabel;
-    }
+  let isThisDaySameAsSelectedStart = thisDay.isSame(selectedStartDate, 'day');
+  let isThisDaySameAsSelectedEnd = thisDay.isSame(selectedEndDate, 'day');
+  // set today's style
+  let isToday = thisDay.isSame(today, 'day');
+  if (isToday) {
+    daySelectedStyle = styles.selectedToday;
+    // todayTextStyle prop overrides selectedDayTextColor (created via makeStyles)
+    selectedDayColorStyle = todayTextStyle || styles.selectedDayLabel;
+  }
 
-    if (Array.isArray(customDatesStyles)) {
-      for (let cds of customDatesStyles) {
-        if (thisDay.isSame(moment(cds.date), 'day')) {
-          customContainerStyle = cds.containerStyle;
-          customDateStyle = cds.style;
-          customTextStyle = cds.textStyle;
-          break;
-        }
+  if (Array.isArray(customDatesStyles)) {
+    for (let cds of customDatesStyles) {
+      if (thisDay.isSame(moment(cds.date), 'day')) {
+        customContainerStyle = cds.containerStyle;
+        customDateStyle = cds.style;
+        customTextStyle = cds.textStyle;
+        break;
       }
     }
-    else if (customDatesStyles instanceof Function) {
-      let cds = customDatesStyles(thisDay) || {};
-      customContainerStyle = cds.containerStyle;
-      customDateStyle = cds.style;
-      customTextStyle = cds.textStyle;
-    }
-    if (isToday && customDateStyle) {
-      // Custom date style overrides 'today' style. It may be reset below
-      // by date selection styling.
-      daySelectedStyle = [daySelectedStyle, customDateStyle];
-    }
+  }
+  else if (customDatesStyles instanceof Function) {
+    let cds = customDatesStyles(thisDay) || {};
+    customContainerStyle = cds.containerStyle;
+    customDateStyle = cds.style;
+    customTextStyle = cds.textStyle;
+  }
+  if (isToday && customDateStyle) {
+    // Custom date style overrides 'today' style. It may be reset below
+    // by date selection styling.
+    daySelectedStyle = [daySelectedStyle, customDateStyle];
+  }
 
-    let isThisDaySameAsSelectedStart = thisDay.isSame(selectedStartDate, 'day');
-    let isThisDaySameAsSelectedEnd = thisDay.isSame(selectedEndDate, 'day');
+  // set selected day style
+  if (!allowRangeSelection &&
+      selectedStartDate &&
+      isThisDaySameAsSelectedStart) {
+    daySelectedStyle = styles.selectedDay;
+    selectedDayColorStyle = [styles.selectedDayLabel, isToday && todayTextStyle];
+    // selectedDayStyle prop overrides selectedDayColor (created via makeStyles)
+    propSelectedDayStyle = selectedDayStyle || styles.selectedDayBackground;
+  }
 
-    // set selected day style
-    if (!allowRangeSelection &&
-        selectedStartDate &&
-        isThisDaySameAsSelectedStart) {
-      daySelectedStyle = styles.selectedDay;
-      selectedDayColorStyle = [styles.selectedDayLabel, isToday && todayTextStyle];
-      // selectedDayStyle prop overrides selectedDayColor (created via makeStyles)
-      propSelectedDayStyle = selectedDayStyle || styles.selectedDayBackground;
-    }
-
-    // Set selected ranges styles
-    if (allowRangeSelection) {
-      if (selectedStartDate && selectedEndDate) {
-        // Apply style for start date
-        if (isThisDaySameAsSelectedStart) {
-          daySelectedStyle = [styles.startDayWrapper, selectedRangeStyle, selectedRangeStartStyle];
-          selectedDayColorStyle = styles.selectedDayLabel;
-        }
-        // Apply style for end date
-        if (isThisDaySameAsSelectedEnd) {
-          daySelectedStyle = [styles.endDayWrapper, selectedRangeStyle, selectedRangeEndStyle];
-          selectedDayColorStyle = styles.selectedDayLabel;
-        }
-        // Apply style if start date is the same as end date
-        if (isThisDaySameAsSelectedEnd &&
-            isThisDaySameAsSelectedStart &&
-            selectedEndDate.isSame(selectedStartDate, 'day')) {
-          daySelectedStyle = [styles.selectedDay, styles.selectedDayBackground, selectedRangeStyle];
-          selectedDayColorStyle = styles.selectedDayLabel;
-        }
-        // Apply style if this day is in range
-        if (thisDay.isBetween(selectedStartDate, selectedEndDate, 'day')) {
-          daySelectedStyle = [styles.inRangeDay, selectedRangeStyle];
-          selectedDayColorStyle = styles.selectedDayLabel;
-        }
-      }
-      // Apply style if start date has been selected but end date has not
-      if (selectedStartDate &&
-          !selectedEndDate &&
-          isThisDaySameAsSelectedStart) {
+  // Set selected ranges styles
+  if (allowRangeSelection) {
+    if (selectedStartDate && selectedEndDate) {
+      // Apply style for start date
+      if (isThisDaySameAsSelectedStart) {
         daySelectedStyle = [styles.startDayWrapper, selectedRangeStyle, selectedRangeStartStyle];
         selectedDayColorStyle = styles.selectedDayLabel;
       }
+      // Apply style for end date
+      if (isThisDaySameAsSelectedEnd) {
+        daySelectedStyle = [styles.endDayWrapper, selectedRangeStyle, selectedRangeEndStyle];
+        selectedDayColorStyle = styles.selectedDayLabel;
+      }
+      // Apply style if start date is the same as end date
+      if (isThisDaySameAsSelectedEnd &&
+          isThisDaySameAsSelectedStart &&
+          selectedEndDate.isSame(selectedStartDate, 'day')) {
+        daySelectedStyle = [styles.selectedDay, styles.selectedDayBackground, selectedRangeStyle];
+        selectedDayColorStyle = styles.selectedDayLabel;
+      }
+      // Apply style if this day is in range
+      if (thisDay.isBetween(selectedStartDate, selectedEndDate, 'day')) {
+        daySelectedStyle = [styles.inRangeDay, selectedRangeStyle];
+        selectedDayColorStyle = styles.selectedDayLabel;
+      }
     }
+    // Apply style if start date has been selected but end date has not
+    if (selectedStartDate &&
+        !selectedEndDate &&
+        isThisDaySameAsSelectedStart) {
+      daySelectedStyle = [styles.startDayWrapper, selectedRangeStyle, selectedRangeStartStyle];
+      selectedDayColorStyle = styles.selectedDayLabel;
+    }
+  }
 
+  // If date is in range let's apply styles
+  if (!dateOutOfRange) {
     return (
       <View style={[styles.dayWrapper, customContainerStyle]}>
         <TouchableOpacity
@@ -190,6 +189,18 @@ export default function Day(props) {
             { day }
           </Text>
         </TouchableOpacity>
+      </View>
+    );
+  }
+  else if (isThisDaySameAsSelectedStart || isThisDaySameAsSelectedEnd) {
+    return (
+      <View style={[styles.dayWrapper, customContainerStyle]}>
+        <View
+          style={[customDateStyle, daySelectedStyle, propSelectedDayStyle ]}>
+          <Text style={[styles.dayLabel, textStyle, customTextStyle, selectedDayColorStyle]}>
+            { day }
+          </Text>
+        </View>
       </View>
     );
   }

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -375,6 +375,7 @@ export default class CalendarPicker extends Component {
       textStyle: this.props.textStyle,
       todayTextStyle: this.props.todayTextStyle,
       selectedDayStyle: this.props.selectedDayStyle,
+      selectedDisabledDatesTextStyle: this.props.selectedDisabledDatesTextStyle,
       selectedRangeStartStyle: this.props.selectedRangeStartStyle,
       selectedRangeStyle: this.props.selectedRangeStyle,
       selectedRangeEndStyle: this.props.selectedRangeEndStyle,

--- a/CalendarPicker/makeStyles.js
+++ b/CalendarPicker/makeStyles.js
@@ -186,6 +186,13 @@ export function makeStyles(params) {
       justifyContent: 'center'
     },
 
+    selectedDisabledText: {
+      fontSize: 14*scaler,
+      color: '#DDDDDD',
+      alignSelf: 'center',
+      justifyContent: 'center'
+    },
+
     monthHeaderMainText: {
       fontSize: 16*scaler,
       color: '#000',


### PR DESCRIPTION
This also changes the style of the first selected date if it's out of range for the second selection to match the valid dates instead of look disabled, however it will not be selectable. 
Fixes #238 