### PR TITLE
Fix issue with editing scroller style on update

### DIFF
--- a/CalendarPicker/Scroller.js
+++ b/CalendarPicker/Scroller.js
@@ -83,7 +83,7 @@ export default class CalendarScroller extends Component {
 
     if (this.props.renderMonthParams.styles !== prevProps.renderMonthParams.styles) {
       updateState = true;
-      newState = this.updateLayout(this.props.renderMonthParams);
+      newState = this.updateLayout(this.props.renderMonthParams.styles);
     }
 
     if (this.props.data !== prevProps.data) {


### PR DESCRIPTION
While I think there are some bigger issues behind how the styles for the calendar are being set (derived state and whatnot), this fixes an issue where, on update of scroller style props, the scroller could render `null` as `height` was `undefined`. Root cause seems to be not passing the right argument to the `updateLayout` helper causing the helper to not create required styles. I observed this when using a parent's `onLayout` to dynamically set the width of the calendar causing the update after the callback was triggered.

Side note: I want to urge the use of TS in this project if ever possible as this bug could have been totally avoided with strong types.