### PR TITLE
Replace moment with date-fns

### DIFF
--- a/CalendarPicker/Day.js
+++ b/CalendarPicker/Day.js
@@ -163,7 +163,9 @@ export default function Day(props) {
           selectedDayTextStyle = [styles.selectedDayLabel, propSelectedDayTextStyle, selectedRangeStartTextStyle];
         }
         // Apply style for days inside of range, excluding start & end dates.
-        if (isWithinInterval(thisDay, { start: selectedStartDate, end: selectedEndDate })) {
+        if (!isThisDaySameAsSelectedEnd &&
+          !isThisDaySameAsSelectedStart &&
+          isWithinInterval(thisDay, { start: selectedStartDate, end: selectedEndDate })) {
           computedSelectedDayStyle = [styles.inRangeDay, selectedRangeStyle];
           selectedDayTextStyle = [styles.selectedDayLabel, propSelectedDayTextStyle];
         }

--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -5,7 +5,7 @@ import { stylePropType } from './localPropTypes';
 import Day from './Day';
 import EmptyDay from './EmptyDay';
 import { Utils } from './Utils';
-import moment from 'moment';
+import { getISODay } from 'date-fns';
 
 export default class DaysGridView extends Component {
   constructor(props) {
@@ -36,12 +36,12 @@ export default class DaysGridView extends Component {
       }
 
       // Create a date for day one of the current given month and year
-      const firstDayOfMonth = moment({ year, month, day: 1 });
+      const firstDayOfMonth = new Date(year, month, 1);
 
       // Determine which day of the week day 1 falls on.
       // See https://github.com/stephy/CalendarPicker/issues/49
       // isoWeekday() gets the ISO day of the week with 1=Monday and 7=Sunday.
-      const firstWeekDay = firstDayOfMonth.isoWeekday();
+      const firstWeekDay = getISODay(firstDayOfMonth);
 
       // Determine starting index based on first day of week prop.
       const startIndex = (firstDay > 0) ? (firstWeekDay + Utils.FIRST_DAY_OFFSETS[firstDay]) % 7 : firstWeekDay;
@@ -87,10 +87,9 @@ export default class DaysGridView extends Component {
       // Check that selected date(s) match this month.
       if (isSelectedDiff && (
         Utils.compareDates(selectedStartDate, firstDayOfMonth, 'month') ||
-          Utils.compareDates(selectedEndDate, firstDayOfMonth, 'month') ||
-          Utils.compareDates(prevSelStart, firstDayOfMonth, 'month') ||
-          Utils.compareDates(prevSelEnd, firstDayOfMonth, 'month') ))
-      {
+        Utils.compareDates(selectedEndDate, firstDayOfMonth, 'month') ||
+        Utils.compareDates(prevSelStart, firstDayOfMonth, 'month') ||
+        Utils.compareDates(prevSelEnd, firstDayOfMonth, 'month'))) {
         // Range selection potentially affects all dates in the month. Recreate.
         if (this.props.allowRangeSelection) {
           this.setState({
@@ -101,8 +100,8 @@ export default class DaysGridView extends Component {
           // Search for affected dates and modify those only
           const daysGrid = [...this.state.daysGrid];
           const { year } = this.props;
-          for (let i = 0; i <daysGrid.length; i++) {
-            for (let j = 0; j <daysGrid[i].length; j++) {
+          for (let i = 0; i < daysGrid.length; i++) {
+            for (let j = 0; j < daysGrid[i].length; j++) {
               const { month, day } = daysGrid[i][j];
               // Empty days and stragglers can't be selected.
               if (month === undefined) { continue; }
@@ -110,8 +109,7 @@ export default class DaysGridView extends Component {
               const thisDay = { year, month, day };
               const isSelected = Utils.compareDates(selectedStartDate, thisDay, 'day');
               const isPrevSelected = Utils.compareDates(prevSelStart, thisDay, 'day');
-              if (isSelected || isPrevSelected)
-              {
+              if (isSelected || isPrevSelected) {
                 daysGrid[i][j] = this.renderDayInCurrentMonth(day);
               }
             }
@@ -147,7 +145,7 @@ export default class DaysGridView extends Component {
     });
   }
 
-  renderDayStraggler({key, day}) {
+  renderDayStraggler({ key, day }) {
     return ({
       day,
       // month doesn't matter for stragglers as long as isn't set to current month
@@ -227,13 +225,13 @@ export default class DaysGridView extends Component {
     const { daysGrid } = this.state;
     const renderedDaysGrid = daysGrid.map((weekRow, i) => (
       <View key={i} style={styles.weekRow}>
-        { weekRow.map(day => day.component ) }
+        {weekRow.map(day => day.component)}
       </View>
     ));
 
     return (
       <View style={styles.daysWrapper}>
-        { renderedDaysGrid }
+        {renderedDaysGrid}
       </View>
     );
   }
@@ -257,7 +255,6 @@ DaysGridView.propTypes = {
       date: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.instanceOf(Date),
-        PropTypes.instanceOf(moment)
       ]),
       containerStyle: stylePropType,
       style: stylePropType,

--- a/CalendarPicker/Month.js
+++ b/CalendarPicker/Month.js
@@ -33,7 +33,7 @@ export default function Month(props) {
     monthIsAfterMax = month > getMonth(maxDate);
   }
   if (minDate && (getYear(minDate) === year)) {
-    monthIsBeforeMin = month < getMonth(month);
+    monthIsBeforeMin = month < getMonth(minDate);
   }
 
   // ToDo: disabledMonths props to disable months separate from disabledDates

--- a/CalendarPicker/Month.js
+++ b/CalendarPicker/Month.js
@@ -6,6 +6,7 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { Utils } from './Utils';
+import { getMonth, getYear } from 'date-fns';
 
 export default function Month(props) {
   const {
@@ -28,11 +29,11 @@ export default function Month(props) {
   let monthIsDisabled = false;
 
   // Check whether month is outside of min/max range.
-  if (maxDate && (maxDate.year() === year)) {
-    monthIsAfterMax = month > maxDate.month();
+  if (maxDate && (getYear(maxDate) === year)) {
+    monthIsAfterMax = month > getMonth(maxDate);
   }
-  if (minDate && (minDate.year() === year)) {
-    monthIsBeforeMin = month < minDate.month();
+  if (minDate && (getYear(minDate) === year)) {
+    monthIsBeforeMin = month < getMonth(month);
   }
 
   // ToDo: disabledMonths props to disable months separate from disabledDates
@@ -41,27 +42,27 @@ export default function Month(props) {
 
   const onSelect = () => {
     let _year = year;
-    if (minDate && (year < minDate.year())) {
-      _year = minDate.year();
+    if (minDate && (year < getYear(minDate))) {
+      _year = getYear(minDate);
     }
-    if (maxDate && (year > maxDate.year())) {
-      _year = maxDate.year();
+    if (maxDate && (year > getYear(maxDate))) {
+      _year = getYear(maxDate);
     }
-    onSelectMonth({month, year: _year});
+    onSelectMonth({ month, year: _year });
   };
 
   return (
     <View style={[styles.monthContainer]}>
-      { !monthOutOfRange ?
+      {!monthOutOfRange ?
         <TouchableOpacity
           onPress={onSelect}>
           <Text style={[styles.monthText, textStyle]}>
-            { monthName }
+            {monthName}
           </Text>
         </TouchableOpacity>
         :
         <Text style={[textStyle, styles.disabledText]}>
-          { monthName }
+          {monthName}
         </Text>
       }
     </View>

--- a/CalendarPicker/Utils.js
+++ b/CalendarPicker/Utils.js
@@ -49,10 +49,10 @@ export const Utils = {
     if (!a && !b) {
       return true;
     }
-    if (granularity === 'days') {
+    if (granularity === 'day') {
       return !!a && !!b && isSameDay(a, b);
     }
-    if (granularity === 'months') {
+    if (granularity === 'month') {
       return !!a && !!b && isSameMonth(a, b);
     }
     return true;

--- a/CalendarPicker/Utils.js
+++ b/CalendarPicker/Utils.js
@@ -5,6 +5,8 @@
  * Licensed under the terms of the MIT license. See LICENSE file in the project root for terms.
  */
 
+import { getMonth, getYear, isSameDay, isSameMonth } from "date-fns";
+
 export const Utils = {
   START_DATE: 'START_DATE',
   END_DATE: 'END_DATE',
@@ -16,20 +18,20 @@ export const Utils = {
   MAX_ROWS: 7,
   MAX_COLUMNS: 7,
   FIRST_DAY_OFFSETS: [0, -1, 5, 4, 3, 2, 1],
-  getDaysInMonth: function(month, year) {
+  getDaysInMonth: function (month, year) {
     const lastDayOfMonth = new Date(year, month + 1, 0);
     return lastDayOfMonth.getDate();
   },
-  isSameMonthAndYear: function(date, month, year) {
+  isSameMonthAndYear: function (date, month, year) {
     if (date) {
-      return date.month() === month && date.year() === year;
+      return getMonth(date) === month && getYear(date) === year;
     }
     return false;
   },
   // Test whether objects' values are different.
   // `exclusions` param ignores provided keys.
   // Returns array of keys that are different (empty array means identical).
-  shallowDiff: function(a, b, exclusions = []) {
+  shallowDiff: function (a, b, exclusions = []) {
     const diffs = [];
     for (let key of Object.keys(a)) {
       if (exclusions.includes(key)) {
@@ -42,14 +44,20 @@ export const Utils = {
     return diffs;
   },
   // Robust compare Moment dates.
-  compareDates: function(a, b, granularity) {
+  compareDates: function (a, b, granularity) {
     // Allow for falsy (null & undefined) equality.
     if (!a && !b) {
       return true;
     }
-    return !!a && !!b && a.isSame(b, granularity);
+    if (granularity === 'days') {
+      return !!a && !!b && isSameDay(a, b);
+    }
+    if (granularity === 'months') {
+      return !!a && !!b && isSameMonth(a, b);
+    }
+    return true;
   },
-  getWeekdays: function(firstDay = 0) {
+  getWeekdays: function (firstDay = 0) {
     let from = firstDay;
     const weekdays = [];
     for (let i = 0; i < Utils.WEEKDAYS.length; i++) {
@@ -58,7 +66,7 @@ export const Utils = {
     }
     return weekdays;
   },
-  getISOWeekdaysOrder: function(firstDay = 0) {
+  getISOWeekdaysOrder: function (firstDay = 0) {
     let from = firstDay === 0 ? 7 : firstDay;
     const order = [];
     for (let i = 0; i < Utils.WEEKDAYS.length; i++) {

--- a/CalendarPicker/Year.js
+++ b/CalendarPicker/Year.js
@@ -5,7 +5,7 @@ import {
   TouchableOpacity
 } from 'react-native';
 import PropTypes from 'prop-types';
-import moment from 'moment';
+import { getMonth, getYear, isAfter, isBefore, startOfMonth } from 'date-fns';
 
 export default function Year(props) {
   const {
@@ -26,10 +26,10 @@ export default function Year(props) {
 
   // Check whether year is outside of min/max range.
   if (maxDate) {
-    yearIsAfterMax = year > maxDate.year();
+    yearIsAfterMax = year > getYear(maxDate);
   }
   if (minDate) {
-    yearIsBeforeMin = year < minDate.year();
+    yearIsBeforeMin = year < getYear(minDate);
   }
 
   // ToDo: disabledYears props to disable years separate from disabledDates
@@ -39,28 +39,28 @@ export default function Year(props) {
   const onSelect = () => {
     // Guard against navigating to months beyond min/max dates.
     let month = currentMonth;
-    let currentMonthYear = moment({year: currentYear, month});
-    if (maxDate && currentMonthYear.isAfter(maxDate, 'month')) {
-      month = maxDate.month();
+    let currentMonthYear = new Date(currentYear, month);
+    if (maxDate && isAfter(currentMonthYear, startOfMonth(maxDate))) {
+      month = getMonth(maxDate);
     }
-    if (minDate && currentMonthYear.isBefore(minDate, 'month')) {
-      month = minDate.month();
+    if (minDate && isBefore(currentMonthYear, startOfMonth(minDate))) {
+      month = getMonth(minDate);
     }
-    onSelectYear({month, year});
+    onSelectYear({ month, year });
   };
 
   return (
     <View style={[styles.yearContainer]}>
-      { !yearOutOfRange ?
+      {!yearOutOfRange ?
         <TouchableOpacity
           onPress={onSelect}>
           <Text style={[styles.yearText, textStyle]}>
-            { year }
+            {year}
           </Text>
         </TouchableOpacity>
         :
         <Text style={[textStyle, styles.disabledText]}>
-          { year }
+          {year}
         </Text>
       }
     </View>

--- a/CalendarPicker/YearsHeader.js
+++ b/CalendarPicker/YearsHeader.js
@@ -7,6 +7,7 @@ import {
 import PropTypes from 'prop-types';
 import { stylePropType } from './localPropTypes';
 import Controls from './Controls';
+import { getYear } from 'date-fns';
 
 export default function YearsHeader(props) {
   const {
@@ -28,8 +29,8 @@ export default function YearsHeader(props) {
     headingLevel,
   } = props;
 
-  const disablePrevious = restrictNavigation && minDate && (minDate.year() >= year);
-  const disableNext = restrictNavigation && maxDate && (maxDate.year() <= year);
+  const disablePrevious = restrictNavigation && minDate && (getYear(minDate) >= year);
+  const disableNext = restrictNavigation && maxDate && (getYear(maxDate) <= year);
 
   const accessibilityProps = { accessibilityRole: 'header' };
   if (Platform.OS === 'web') {
@@ -47,7 +48,7 @@ export default function YearsHeader(props) {
         textStyles={[styles.navButtonText, textStyle, previousTitleStyle]}
       />
       <Text style={[styles.yearsHeaderText, textStyle]} {...accessibilityProps}>
-        { title }
+        {title}
       </Text>
       <Controls
         disabled={disableNext}

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -8,7 +8,7 @@ import DaysGridView from './DaysGridView';
 import MonthSelector from './MonthSelector';
 import YearSelector from './YearSelector';
 import Scroller from './Scroller';
-import moment from 'moment';
+import { addMonths, getMonth, getYear, isAfter, isBefore, isSameDay, isSameMonth, startOfMonth, subMonths } from 'date-fns';
 
 export default class CalendarPicker extends Component {
   constructor(props) {
@@ -18,10 +18,10 @@ export default class CalendarPicker extends Component {
       currentMonth: null,
       currentYear: null,
       currentView: props.initialView || 'days',
-      selectedStartDate: props.selectedStartDate && moment(props.selectedStartDate),
-      selectedEndDate: props.selectedEndDate && moment(props.selectedEndDate),
-      minDate: props.minDate && moment(props.minDate),
-      maxDate: props.maxDate && moment(props.maxDate),
+      selectedStartDate: props.selectedStartDate && new Date(props.selectedStartDate),
+      selectedEndDate: props.selectedEndDate && new Date(props.selectedEndDate),
+      minDate: props.minDate && new Date(props.minDate),
+      maxDate: props.maxDate && new Date(props.maxDate),
       styles: {},
       ...this.updateScaledStyles(props),
       ...this.updateMonthYear(props.initialDate),
@@ -33,7 +33,7 @@ export default class CalendarPicker extends Component {
   }
 
   static defaultProps = {
-    initialDate: moment(),
+    initialDate: new Date(),
     scaleFactor: 375,
     scrollable: false,
     onDateChange: () => {
@@ -48,7 +48,7 @@ export default class CalendarPicker extends Component {
     selectMonthTitle: 'Select Month in ',
     selectYearTitle: 'Select Year',
     horizontal: true,
-    selectedDayStyle : null,
+    selectedDayStyle: null,
     selectedRangeStartStyle: null,
     selectedRangeEndStyle: null,
     selectedRangeStyle: null,
@@ -67,7 +67,8 @@ export default class CalendarPicker extends Component {
     }
 
     let newMonthYear = {};
-    if (!moment(prevProps.initialDate).isSame(this.props.initialDate, 'day')) {
+
+    if (!isSameDay(prevProps.initialDate, this.props.initialDate)) {
       newMonthYear = this.updateMonthYear(this.props.initialDate);
       doStateUpdate = true;
     }
@@ -75,11 +76,11 @@ export default class CalendarPicker extends Component {
     let selectedDateRanges = {};
     const { selectedStartDate, selectedEndDate } = this.props;
     if (selectedStartDate !== prevProps.selectedStartDate ||
-        selectedEndDate !== prevProps.selectedEndDate
+      selectedEndDate !== prevProps.selectedEndDate
     ) {
       selectedDateRanges = {
-        selectedStartDate: selectedStartDate && moment(selectedStartDate),
-        selectedEndDate: selectedEndDate && moment(selectedEndDate)
+        selectedStartDate: selectedStartDate && new Date(selectedStartDate),
+        selectedEndDate: selectedEndDate && new Date(selectedEndDate)
       };
       doStateUpdate = true;
     }
@@ -92,19 +93,19 @@ export default class CalendarPicker extends Component {
 
     let rangeDurations = {};
     if (prevProps.minRangeDuration !== this.props.minRangeDuration ||
-        prevProps.maxRangeDuration !== this.props.maxRangeDuration
+      prevProps.maxRangeDuration !== this.props.maxRangeDuration
     ) {
-      const {minRangeDuration, maxRangeDuration} = this.props;
+      const { minRangeDuration, maxRangeDuration } = this.props;
       rangeDurations = this.updateMinMaxRanges(minRangeDuration, maxRangeDuration);
       doStateUpdate = true;
     }
 
     let minMaxDates = {};
     if (prevProps.minDate !== this.props.minDate ||
-        prevProps.minDate !== this.props.minDate
+      prevProps.minDate !== this.props.minDate
     ) {
-      minMaxDates.minDate = this.props.minDate && moment(this.props.minDate);
-      minMaxDates.maxDate = this.props.maxDate && moment(this.props.maxDate);
+      minMaxDates.minDate = this.props.minDate && new Date(this.props.minDate);
+      minMaxDates.maxDate = this.props.maxDate && new Date(this.props.maxDate);
       doStateUpdate = true;
     }
 
@@ -123,9 +124,9 @@ export default class CalendarPicker extends Component {
         ...minMaxDates,
       };
       let renderMonthParams = {};
-      const _state = {...this.state, ...newState};
+      const _state = { ...this.state, ...newState };
       renderMonthParams = this.createMonthProps(_state);
-      this.setState({...newState, renderMonthParams});
+      this.setState({ ...newState, renderMonthParams });
     }
   }
 
@@ -158,8 +159,8 @@ export default class CalendarPicker extends Component {
 
   updateMonthYear = (initialDate = this.props.initialDate, updateState) => {
     const newState = {
-      currentMonth: parseInt(moment(initialDate).month()),
-      currentYear: parseInt(moment(initialDate).year())
+      currentMonth: parseInt(getMonth(new Date(initialDate))),
+      currentYear: parseInt(getYear(new Date(initialDate)))
     };
     if (updateState) {
       this.setState(newState);
@@ -173,8 +174,8 @@ export default class CalendarPicker extends Component {
       if (Array.isArray(_disabledDates)) {
         // Convert input date into timestamp
         _disabledDates.map(date => {
-          let thisDate = moment(date);
-          thisDate.set({ hour: 12, minute: 0, second: 0, millisecond: 0 });
+          let thisDate = new Date(date);
+          thisDate.setHours(12, 0, 0, 0);
           disabledDates.push(thisDate.valueOf());
         });
       }
@@ -192,8 +193,8 @@ export default class CalendarPicker extends Component {
     if (_minRangeDuration) {
       if (Array.isArray(_minRangeDuration)) {
         _minRangeDuration.map(mrd => {
-          let thisDate = moment(mrd.date);
-          thisDate.set({ hour: 12, minute: 0, second: 0, millisecond: 0 });
+          let thisDate = new Date(mrd.date);
+          thisDate.setHours(12, 0, 0, 0);
           minRangeDuration.push({
             date: thisDate.valueOf(),
             minDuration: mrd.minDuration
@@ -207,8 +208,8 @@ export default class CalendarPicker extends Component {
     if (_maxRangeDuration) {
       if (Array.isArray(_maxRangeDuration)) {
         _maxRangeDuration.map(mrd => {
-          let thisDate = moment(mrd.date);
-          thisDate.set({ hour: 12, minute: 0, second: 0, millisecond: 0 });
+          let thisDate = new Date(mrd.date);
+          thisDate.setHours(12, 0, 0, 0);
           maxRangeDuration.push({
             date: thisDate.valueOf(),
             maxDuration: mrd.maxDuration
@@ -218,10 +219,10 @@ export default class CalendarPicker extends Component {
         maxRangeDuration = _maxRangeDuration;
       }
     }
-    return {minRangeDuration, maxRangeDuration};
+    return { minRangeDuration, maxRangeDuration };
   }
 
-  handleOnPressDay = ({year, month, day}) => {
+  handleOnPressDay = ({ year, month, day }) => {
     const {
       selectedStartDate: prevSelectedStartDate,
       selectedEndDate: prevSelectedEndDate,
@@ -238,27 +239,27 @@ export default class CalendarPicker extends Component {
       return;
     }
 
-    const date = moment({ year, month, day, hour: 12 });
+    const date = new Date(year, month, day, 12);
 
     if (allowRangeSelection && prevSelectedStartDate && !prevSelectedEndDate) {
-      if (date.isSameOrAfter(prevSelectedStartDate, 'day')) {
+      if (!isBefore(prevSelectedStartDate, date)) {
         const selectedStartDate = prevSelectedStartDate;
         const selectedEndDate = date;
         this.setState({
           selectedEndDate,
-          renderMonthParams: this.createMonthProps({...this.state, selectedStartDate, selectedEndDate}),
+          renderMonthParams: this.createMonthProps({ ...this.state, selectedStartDate, selectedEndDate }),
         });
         // Sync end date with parent
         onDateChange(date, Utils.END_DATE);
       }
       else if (allowBackwardRangeSelect) { // date is before selectedStartDate
         // Flip dates so that start is always before end.
-        const selectedEndDate = prevSelectedStartDate.clone();
+        const selectedEndDate = new Date(prevSelectedStartDate);
         const selectedStartDate = date;
         this.setState({
           selectedStartDate,
           selectedEndDate,
-          renderMonthParams: this.createMonthProps({...this.state, selectedStartDate, selectedEndDate}),
+          renderMonthParams: this.createMonthProps({ ...this.state, selectedStartDate, selectedEndDate }),
         }, () => {
           // Sync both start and end dates with parent *after* state update.
           onDateChange(this.state.selectedStartDate, Utils.START_DATE);
@@ -272,7 +273,7 @@ export default class CalendarPicker extends Component {
       this.setState({
         selectedStartDate,
         selectedEndDate,
-        renderMonthParams: this.createMonthProps({...this.state, selectedStartDate, selectedEndDate}),
+        renderMonthParams: this.createMonthProps({ ...this.state, selectedStartDate, selectedEndDate }),
       }, () => {
         // Sync start date with parent *after* state update.
         onDateChange(this.state.selectedStartDate, Utils.START_DATE);
@@ -295,7 +296,7 @@ export default class CalendarPicker extends Component {
       year--;
     }
     const scrollFinisher = this.props.scrollable && this.scroller.scrollLeft;
-    this.handleOnPressFinisher({year, month: previousMonth, scrollFinisher});
+    this.handleOnPressFinisher({ year, month: previousMonth, scrollFinisher });
   }
 
   handleOnPressNext = () => {
@@ -309,10 +310,10 @@ export default class CalendarPicker extends Component {
       year++;
     }
     const scrollFinisher = this.props.scrollable && this.scroller.scrollRight;
-    this.handleOnPressFinisher({year, month: nextMonth, scrollFinisher});
+    this.handleOnPressFinisher({ year, month: nextMonth, scrollFinisher });
   }
 
-  handleOnPressFinisher = ({year, month, scrollFinisher, extraState}) => {
+  handleOnPressFinisher = ({ year, month, scrollFinisher, extraState }) => {
     if (scrollFinisher) {
       scrollFinisher();
     }
@@ -320,11 +321,11 @@ export default class CalendarPicker extends Component {
       const currentMonth = parseInt(month);
       const currentYear = parseInt(year);
       const renderMonthParams = extraState || {
-        renderMonthParams: {...this.state.renderMonthParams, month, year}
+        renderMonthParams: { ...this.state.renderMonthParams, month, year }
       };
       this.setState({ currentMonth, currentYear, ...renderMonthParams });
     }
-    const currentMonthYear = moment({year, month, hour: 12});
+    const currentMonthYear = new Date(year, month, 1, 12);
     this.props.onMonthChange && this.props.onMonthChange(currentMonthYear);
   }
 
@@ -340,27 +341,27 @@ export default class CalendarPicker extends Component {
     });
   }
 
-  handleOnSelectMonthYear = ({month, year}) => {
+  handleOnSelectMonthYear = ({ month, year }) => {
     const currentYear = year;
     const currentMonth = month;
     const scrollableState = this.props.scrollable ? {
-      ...this.createMonths(this.props, {currentYear, currentMonth}),
+      ...this.createMonths(this.props, { currentYear, currentMonth }),
     } : {};
 
     const extraState = {
-      renderMonthParams: {...this.state.renderMonthParams, month, year},
+      renderMonthParams: { ...this.state.renderMonthParams, month, year },
       currentView: 'days',
       ...scrollableState,
     };
 
-    this.handleOnPressFinisher({month, year, extraState});
+    this.handleOnPressFinisher({ month, year, extraState });
   }
 
   resetSelections = () => {
     this.setState((state) => ({
       selectedStartDate: null,
       selectedEndDate: null,
-      renderMonthParams: { 
+      renderMonthParams: {
         ...state.renderMonthParams,
         selectedStartDate: null,
         selectedEndDate: null,
@@ -401,7 +402,7 @@ export default class CalendarPicker extends Component {
     };
   }
 
-  createMonths = (props, {currentMonth, currentYear}) => {
+  createMonths = (props, { currentMonth, currentYear }) => {
     if (!props.scrollable) {
       return [];
     }
@@ -420,19 +421,19 @@ export default class CalendarPicker extends Component {
     // Center start month in scroller.  Visible month is either the initialDate
     // prop, or the current month & year that has been selected.
     let _initialDate = Number.isInteger(currentMonth) && Number.isInteger(currentYear) &&
-        moment({ year: currentYear, month: currentMonth, hour: 12 });
+      new Date(currentYear, currentMonth, 1, 12);
     _initialDate = _initialDate || initialDate;
-    let firstScrollerMonth = _initialDate.clone().subtract(numMonths/2, 'months');
-    if (minDate && restrictMonthNavigation && firstScrollerMonth.isBefore(minDate, 'month')) {
-      firstScrollerMonth = moment(minDate);
+    let firstScrollerMonth = subMonths(_initialDate, numMonths / 2);
+    if (minDate && restrictMonthNavigation && isBefore(startOfMonth(firstScrollerMonth), startOfMonth(minDate))) {
+      firstScrollerMonth = new Date(minDate);
     }
 
     for (let i = 0; i < numMonths; i++) {
-      let month = firstScrollerMonth.clone().add(i, 'months');
-      if (maxDate && restrictMonthNavigation && month.isAfter(maxDate, 'month')) {
+      let month = addMonths(firstScrollerMonth, i);
+      if (maxDate && restrictMonthNavigation && isAfter(startOfMonth(month), startOfMonth(maxDate))) {
         break;
       }
-      if (month.isSame(_initialDate, 'month')) {
+      if (isSameMonth(month, _initialDate)) {
         initialScrollerIndex = i;
       }
       monthsList.push(month);
@@ -493,103 +494,103 @@ export default class CalendarPicker extends Component {
 
     let content;
     switch (currentView) {
-    case 'months':
-      content = (
-        <MonthSelector
-          styles={styles}
-          textStyle={textStyle}
-          title={selectMonthTitle}
-          currentYear={currentYear}
-          months={months}
-          minDate={minDate}
-          maxDate={maxDate}
-          onSelectMonth={this.handleOnSelectMonthYear}
-          headingLevel={headingLevel}
-        />
-      );
-      break;
-    case 'years':
-      content = (
-        <YearSelector
-          styles={styles}
-          textStyle={textStyle}
-          title={selectYearTitle}
-          initialDate={moment(initialDate)}
-          currentMonth={currentMonth}
-          currentYear={currentYear}
-          minDate={minDate}
-          maxDate={maxDate}
-          restrictNavigation={restrictMonthNavigation}
-          previousComponent={previousComponent}
-          nextComponent={nextComponent}
-          previousTitle={previousTitle}
-          nextTitle={nextTitle}
-          previousTitleStyle={previousTitleStyle}
-          nextTitleStyle={nextTitleStyle}
-          onSelectYear={this.handleOnSelectMonthYear}
-          headingLevel={headingLevel}
-        />
-      );
-      break;
-    default:
-      content = (
-        <View styles={styles.calendar}>
-          <HeaderControls
+      case 'months':
+        content = (
+          <MonthSelector
             styles={styles}
+            textStyle={textStyle}
+            title={selectMonthTitle}
+            currentYear={currentYear}
+            months={months}
+            minDate={minDate}
+            maxDate={maxDate}
+            onSelectMonth={this.handleOnSelectMonthYear}
+            headingLevel={headingLevel}
+          />
+        );
+        break;
+      case 'years':
+        content = (
+          <YearSelector
+            styles={styles}
+            textStyle={textStyle}
+            title={selectYearTitle}
+            initialDate={new Date(initialDate)}
             currentMonth={currentMonth}
             currentYear={currentYear}
-            initialDate={moment(initialDate)}
-            onPressPrevious={this.handleOnPressPrevious}
-            onPressNext={this.handleOnPressNext}
-            onPressMonth={this.handleOnPressMonth}
-            onPressYear={this.handleOnPressYear}
-            months={months}
+            minDate={minDate}
+            maxDate={maxDate}
+            restrictNavigation={restrictMonthNavigation}
             previousComponent={previousComponent}
             nextComponent={nextComponent}
             previousTitle={previousTitle}
             nextTitle={nextTitle}
             previousTitleStyle={previousTitleStyle}
             nextTitleStyle={nextTitleStyle}
-            monthTitleStyle={monthTitleStyle}
-            yearTitleStyle={yearTitleStyle}
-            textStyle={textStyle}
-            restrictMonthNavigation={restrictMonthNavigation}
-            minDate={minDate}
-            maxDate={maxDate}
+            onSelectYear={this.handleOnSelectMonthYear}
             headingLevel={headingLevel}
-            monthYearHeaderWrapperStyle={monthYearHeaderWrapperStyle}
-            headerWrapperStyle={headerWrapperStyle}
           />
-          <Weekdays
-            styles={styles}
-            firstDay={startFromMonday ? 1 : firstDay}
-            currentMonth={currentMonth}
-            currentYear={currentYear}
-            weekdays={weekdays}
-            textStyle={textStyle}
-            dayLabelsWrapper={dayLabelsWrapper}
-            customDayHeaderStyles={customDayHeaderStyles}
-          />
-          { scrollable ?
-            <Scroller
-              ref={scroller => this.scroller = scroller}
-              data={monthsList}
-              renderMonth={this.renderMonth}
-              renderMonthParams={renderMonthParams}
-              maxSimultaneousMonths={this.numMonthsScroll}
-              initialRenderIndex={initialScrollerIndex}
+        );
+        break;
+      default:
+        content = (
+          <View styles={styles.calendar}>
+            <HeaderControls
+              styles={styles}
+              currentMonth={currentMonth}
+              currentYear={currentYear}
+              initialDate={new Date(initialDate)}
+              onPressPrevious={this.handleOnPressPrevious}
+              onPressNext={this.handleOnPressNext}
+              onPressMonth={this.handleOnPressMonth}
+              onPressYear={this.handleOnPressYear}
+              months={months}
+              previousComponent={previousComponent}
+              nextComponent={nextComponent}
+              previousTitle={previousTitle}
+              nextTitle={nextTitle}
+              previousTitleStyle={previousTitleStyle}
+              nextTitleStyle={nextTitleStyle}
+              monthTitleStyle={monthTitleStyle}
+              yearTitleStyle={yearTitleStyle}
+              textStyle={textStyle}
+              restrictMonthNavigation={restrictMonthNavigation}
               minDate={minDate}
               maxDate={maxDate}
-              restrictMonthNavigation={restrictMonthNavigation}
-              updateMonthYear={this.updateMonthYear}
-              onMonthChange={onMonthChange}
-              horizontal={horizontal}
+              headingLevel={headingLevel}
+              monthYearHeaderWrapperStyle={monthYearHeaderWrapperStyle}
+              headerWrapperStyle={headerWrapperStyle}
             />
-            :
-            this.renderMonth(renderMonthParams)
-          }
-        </View>
-      );
+            <Weekdays
+              styles={styles}
+              firstDay={startFromMonday ? 1 : firstDay}
+              currentMonth={currentMonth}
+              currentYear={currentYear}
+              weekdays={weekdays}
+              textStyle={textStyle}
+              dayLabelsWrapper={dayLabelsWrapper}
+              customDayHeaderStyles={customDayHeaderStyles}
+            />
+            {scrollable ?
+              <Scroller
+                ref={scroller => this.scroller = scroller}
+                data={monthsList}
+                renderMonth={this.renderMonth}
+                renderMonthParams={renderMonthParams}
+                maxSimultaneousMonths={this.numMonthsScroll}
+                initialRenderIndex={initialScrollerIndex}
+                minDate={minDate}
+                maxDate={maxDate}
+                restrictMonthNavigation={restrictMonthNavigation}
+                updateMonthYear={this.updateMonthYear}
+                onMonthChange={onMonthChange}
+                horizontal={horizontal}
+              />
+              :
+              this.renderMonth(renderMonthParams)
+            }
+          </View>
+        );
     }
 
     return content;

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -242,7 +242,7 @@ export default class CalendarPicker extends Component {
     const date = new Date(year, month, day, 12);
 
     if (allowRangeSelection && prevSelectedStartDate && !prevSelectedEndDate) {
-      if (!isBefore(prevSelectedStartDate, date)) {
+      if (!isAfter(date, prevSelectedEndDate)) {
         const selectedStartDate = prevSelectedStartDate;
         const selectedEndDate = date;
         this.setState({

--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 
 This is a Calendar Picker Component for React Native
 
-### Migrated from moment to date-fns - New in 8.x
+### Breaking changes in 8.x - replaced moment with date-fns
 
-We've migrated away from [moment.js](https://github.com/moment/moment), in favor of [date-fns](https://date-fns.org/), a modular and lightweight alternative. These changes should be backwards compatible, with no migration steps required in order to upgrade from earlier versions of `react-native-calendar-picker`.
+We've migrated away from [moment.js](https://github.com/moment/moment), in favor of [date-fns](https://date-fns.org/), a modular and lightweight alternative. Users wanting to continue to use Moment should stick with 7.x
+
+# Prerequisites
+
+CalendarPicker requires date-fns >=3.0. Date props may be anything parseable by the [Javascript Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), such as a Javascript Date, or ISO8601 datetime string.
+
+```
+npm install --save date-fns
+```
 
 ### Scrollable CalendarPicker — New in 7.x
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This is a Calendar Picker Component for React Native
 
+### Migrated from moment to date-fns - New in 8.x
+
+We've migrated away from [moment.js](https://github.com/moment/moment), in favor of [date-fns](https://date-fns.org/), a modular and lightweight alternative. These changes should be backwards compatible, with no migration steps required in order to upgrade from earlier versions of `react-native-calendar-picker`.
+
 ### Scrollable CalendarPicker — New in 7.x
 
 The `scrollable` prop was introduced in 7.0.0 and features a bi-directional infinite scroller. It recycles months using RecyclerListView, shifting them as the ends are reached. If the Chrome debugger is used during development, month shifting may be erratic due to a [RN setTimeout bug](https://github.com/facebook/react-native/issues/4470). To prevent month shifts at the ends of the scroller, set `restrictMonthNavigation`, `minDate`, and `maxDate` range to 5 years or less.
@@ -11,28 +15,17 @@ The `scrollable` prop was introduced in 7.0.0 and features a bi-directional infi
 ![alt tag](https://user-images.githubusercontent.com/6295083/82028634-87a2b880-965b-11ea-90ce-1bde67f31157.gif)
 
 To use the calendar you just need to:
+
 ```sh
 npm install --save react-native-calendar-picker
-```
-
-# Prerequisites
-
-CalendarPicker requires Moment JS >=2.0.  Date props may be anything parseable by Moment: Javascript Date, Moment date, or ISO8601 datetime string.
-
-```
-npm install --save moment
 ```
 
 # Example
 
 ```js
-import React, { Component } from 'react';
-import {
-  StyleSheet,
-  Text,
-  View
-} from 'react-native';
-import CalendarPicker from 'react-native-calendar-picker';
+import React, { Component } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import CalendarPicker from "react-native-calendar-picker";
 
 export default class App extends Component {
   constructor(props) {
@@ -50,15 +43,13 @@ export default class App extends Component {
   }
   render() {
     const { selectedStartDate } = this.state;
-    const startDate = selectedStartDate ? selectedStartDate.toString() : '';
+    const startDate = selectedStartDate ? selectedStartDate.toString() : "";
     return (
       <View style={styles.container}>
-        <CalendarPicker
-          onDateChange={this.onDateChange}
-        />
+        <CalendarPicker onDateChange={this.onDateChange} />
 
         <View>
-          <Text>SELECTED DATE:{ startDate }</Text>
+          <Text>SELECTED DATE:{startDate}</Text>
         </View>
       </View>
     );
@@ -68,78 +59,82 @@ export default class App extends Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#FFFFFF',
+    backgroundColor: "#FFFFFF",
     marginTop: 100,
   },
 });
 ```
+
 ## CalendarPicker Props
-| Prop | Type | Description |
-:------------ |:---------------| :-----|
-| **`weekdays`** | `Array` | Optional. List of week days. Eg. `['Mon', 'Tue', ...]` Must be 7 days |
-| **`months`** | `Array` | Optional. List of months names. Eg. `['Jan', 'Feb', ...]` Must be 12 months |
-| **`firstDay`** | `Number` | Optional. Default first day of week will be Sunday. You can set start of week with number from `0` to `6`. Default is `0` or Sunday |
-| **`startFromMonday`** | `Boolean` | Optional. Default first day of week will be Sunday. You can set start of week from Monday by setting this to true. Default is `false` |
-| **`showDayStragglers`** | `Boolean` | Optional. Populate previous & next month days in empty slots. Default is `false` |
-| **`allowRangeSelection`** | `Boolean` | Optional. Allow to select date ranges. Default is `false` |
-| **`allowBackwardRangeSelect`** | `Boolean` | Optional. Allow selecting range in reverse. Default is `false` |
-| **`previousTitle`** | `String` | Optional. Title of button for previous month. Default is `Previous` |
-| **`nextTitle`** | `String` | Optional. Title of button for next month. Default is `Next` |
-| **`previousTitleStyle`** | `TextStyle` | Optional. Text styling for Previous text.|
-| **`nextTitleStyle`** | `TextStyle` | Optional. Text styling for Next text.|
-| **`previousComponent`** | `Object` | Optional. Component to use in `Previous` button. Overrides `previousTitle` & `previousTitleStyle`. |
-| **`nextComponent`** | `Object` | Optional. Component to use in `Next` button. Overrides `nextTitle` & `nextTitleStyle`.  |
-| **`selectedDayColor`** | `String` | Optional. Color for selected day |
-| **`selectedDayStyle`** | `ViewStyle` | Optional. Style for selected day. May override selectedDayColor.|
-| **`selectedDayTextColor`** | `String` | Optional. Text color for selected day |
-| **`selectedDayTextStyle`** | `Object` | Optional. Text style for selected day (including all days in range) |
-| **`selectedRangeStartTextStyle`** | `Object` | Optional. Text style for start day of range |
-| **`selectedRangeEndTextStyle`** | `Object` | Optional. Text style for end day of range |
-| **`selectedRangeStartStyle`** | `ViewStyle` | Optional. Container style for start day of range. |
-| **`selectedRangeEndStyle`** | `ViewStyle` | Optional. Container style for end day of range. |
-| **`selectedRangeStyle`** | `ViewStyle` | Optional. Container style for all days in range selection. |
-| **`selectedDisabledDatesTextStyle`** | `Object` | Optional. Text style for ineligible dates during range selection. |
-| **`disabledDates`** | `Array` or `Function` | Optional. Specifies dates that cannot be selected. Array of Dates, or a function that returns true for a given Moment date (apologies for the inverted logic). |
-| **`disabledDatesTextStyle`** | `TextStyle` | Optional. Text styling for disabled dates. |
-| **`selectedStartDate`** | `Date` | Optional. Specifies a selected Start Date. |
-| **`selectedEndDate`** | `Date` | Optional. Specifies a selected End Date. |
-| **`minRangeDuration`** | `Number or Array` | Optional. Specifies a minimum range duration when using allowRangeSelection. Can either pass a number to be used for all dates or an Array of objects if the minimum range duration depends on the date `{date: Moment-parsable date, minDuration: Number}` |
-| **`maxRangeDuration`** | `Number or Array` | Optional. Specifies a maximum range duration when using allowRangeSelection. Can either pass a number to be used for all dates or an Array of objects if the maximum range duration depends on the date `{date: Moment-parsable date, maxDuration: Number}` |
-| **`todayBackgroundColor`** | `String` | Optional. Background color for today. Default is `#cccccc` |
-| **`todayTextStyle`** | `TextStyle` | Optional. Text styling for today. |
-| **`textStyle`** | `TextStyle` | Optional. Style overall text. Change fontFamily, color, etc. |
-| **`customDatesStyles`** | `Array` or `Func` | Optional. Style individual date(s). Supports an array of objects `{date: Moment-parseable date, containerStyle: ViewStyle, style: ViewStyle, textStyle: TextStyle, allowDisabled: Boolean}`, or a callback which receives a date param and returns `{containerStyle: ViewStyle, style: ViewStyle, textStyle: TextStyle, allowDisabled: Boolean}` for that date. |
-| **`customDayHeaderStyles`** | `Func` | Optional. Style day of week header (Monday - Sunday). Callback that receives ISO `{dayOfWeek, month, year}` and should return `{style: ViewStyle, textStyle: TextStyle}` |
-| **`scaleFactor`** | `Number` | Optional. Default (375) scales to window width |
-| **`minDate`** | `Date` | Optional. Specifies minimum date to be selected |
-| **`maxDate`** | `Date` | Optional. Specifies maximum date to be selected |
-| **`initialDate`** | `Date` | Optional. Date that calendar opens to. Defaults to today. |
-| **`width`** | `Number` | Optional. Width of CalendarPicker's container. Defaults to Dimensions width.|
-| **`height`** | `Number` | Optional. Height of CalendarPicker's container. Defaults to Dimensions height.|
-| **`scrollable`**                | `Boolean`    | Optional. Months are scrollable if true. Default is `false` |
-| **`horizontal`**                | `Boolean`    | Optional. Scroll axis when `scrollable` set. Default is `true` |
-| **`enableDateChange`** | `Boolean` | Optional. Whether to enable pressing on day. Default is `true` |
-| **`restrictMonthNavigation`** | `Boolean` | Optional. Whether to disable Previous month button if it is before minDate or Next month button if it is after MaxDate. Default is `false` |
-| **`onDateChange`** | `Function` | Optional. Callback when a date is selected. Returns Moment `date` as first param; `START_DATE` or `END_DATE` as second param.|
-| **`onMonthChange`** | `Function` | Optional. Callback when Previous / Next month is pressed. Returns Moment `date` as first parameter.|
-| **`dayShape`** | `String` | Optional. Shape of the Day component. Default is `circle`. Available options are `circle` and `square`.|
-| **`headingLevel`** | `Number` | Optional. Sets the aria-level for the calendar title heading when on Web. Default is `1`.|
-| **`selectMonthTitle`** | `String` | Optional. Title of month selector view. Default is "Select Month in " + {year}.|
-| **`selectYearTitle`** | `String` | Optional. Title of year selector view. Default is "Select Year".|
-| **`dayLabelsWrapper`** | `ViewStyle` | Optional. Style for weekdays wrapper. E.g If you want to remove top and bottom divider line.|
-| **`enableSwipe`**               | `Deprecated` | Use `scrollable`. |
-| **`swipeConfig`**               | `Deprecated` | Use `scrollable`. |
-| **`onSwipe`**                   | `Deprecated` | Use `onMonthChange`. |
-| **`dayOfWeekStyles`**           | `Deprecated` | Use `customDatesStyles` & `customDayHeaderStyles` callbacks to style individual dates, days of week, and/or header. |
-| **`customDatesStylesPriority`** | `Deprecated` | Use `customDatesStyles` & `customDayHeaderStyles` callbacks to style individual dates, days of week, and/or header. |
-| **`monthYearHeaderWrapperStyle`** | `ViewStyle` | Optional. Style for header MonthYear title wrapper. E.g If you want to change the order of year and month.|
-| **`headerWrapperStyle`** | `ViewStyle` | Optional. Style for entire header controls wrapper. This contains the previous / next controls plus month & year.|
-| **`monthTitleStyle`** | `TextStyle` | Optional. Text styling for header's month text.|
-| **`yearTitleStyle`** | `TextStyle` | Optional. Text styling for header's year text.|
-| **`initialView`** | `String` | Optional. The view that the calendar opens to. Default is `days`. Available options are `years`, `months`, and `days`.|
+
+| Prop                                 | Type                  | Description                                                                                                                                                                                                                                                                                                                                              |
+| :----------------------------------- | :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`weekdays`**                       | `Array`               | Optional. List of week days. Eg. `['Mon', 'Tue', ...]` Must be 7 days                                                                                                                                                                                                                                                                                    |
+| **`months`**                         | `Array`               | Optional. List of months names. Eg. `['Jan', 'Feb', ...]` Must be 12 months                                                                                                                                                                                                                                                                              |
+| **`firstDay`**                       | `Number`              | Optional. Default first day of week will be Sunday. You can set start of week with number from `0` to `6`. Default is `0` or Sunday                                                                                                                                                                                                                      |
+| **`startFromMonday`**                | `Boolean`             | Optional. Default first day of week will be Sunday. You can set start of week from Monday by setting this to true. Default is `false`                                                                                                                                                                                                                    |
+| **`showDayStragglers`**              | `Boolean`             | Optional. Populate previous & next month days in empty slots. Default is `false`                                                                                                                                                                                                                                                                         |
+| **`allowRangeSelection`**            | `Boolean`             | Optional. Allow to select date ranges. Default is `false`                                                                                                                                                                                                                                                                                                |
+| **`allowBackwardRangeSelect`**       | `Boolean`             | Optional. Allow selecting range in reverse. Default is `false`                                                                                                                                                                                                                                                                                           |
+| **`previousTitle`**                  | `String`              | Optional. Title of button for previous month. Default is `Previous`                                                                                                                                                                                                                                                                                      |
+| **`nextTitle`**                      | `String`              | Optional. Title of button for next month. Default is `Next`                                                                                                                                                                                                                                                                                              |
+| **`previousTitleStyle`**             | `TextStyle`           | Optional. Text styling for Previous text.                                                                                                                                                                                                                                                                                                                |
+| **`nextTitleStyle`**                 | `TextStyle`           | Optional. Text styling for Next text.                                                                                                                                                                                                                                                                                                                    |
+| **`previousComponent`**              | `Object`              | Optional. Component to use in `Previous` button. Overrides `previousTitle` & `previousTitleStyle`.                                                                                                                                                                                                                                                       |
+| **`nextComponent`**                  | `Object`              | Optional. Component to use in `Next` button. Overrides `nextTitle` & `nextTitleStyle`.                                                                                                                                                                                                                                                                   |
+| **`selectedDayColor`**               | `String`              | Optional. Color for selected day                                                                                                                                                                                                                                                                                                                         |
+| **`selectedDayStyle`**               | `ViewStyle`           | Optional. Style for selected day. May override selectedDayColor.                                                                                                                                                                                                                                                                                         |
+| **`selectedDayTextColor`**           | `String`              | Optional. Text color for selected day                                                                                                                                                                                                                                                                                                                    |
+| **`selectedDayTextStyle`**           | `Object`              | Optional. Text style for selected day (including all days in range)                                                                                                                                                                                                                                                                                      |
+| **`selectedRangeStartTextStyle`**    | `Object`              | Optional. Text style for start day of range                                                                                                                                                                                                                                                                                                              |
+| **`selectedRangeEndTextStyle`**      | `Object`              | Optional. Text style for end day of range                                                                                                                                                                                                                                                                                                                |
+| **`selectedRangeStartStyle`**        | `ViewStyle`           | Optional. Container style for start day of range.                                                                                                                                                                                                                                                                                                        |
+| **`selectedRangeEndStyle`**          | `ViewStyle`           | Optional. Container style for end day of range.                                                                                                                                                                                                                                                                                                          |
+| **`selectedRangeStyle`**             | `ViewStyle`           | Optional. Container style for all days in range selection.                                                                                                                                                                                                                                                                                               |
+| **`selectedDisabledDatesTextStyle`** | `Object`              | Optional. Text style for ineligible dates during range selection.                                                                                                                                                                                                                                                                                        |
+| **`disabledDates`**                  | `Array` or `Function` | Optional. Specifies dates that cannot be selected. Array of Dates, or a function that returns true for a given date (apologies for the inverted logic).                                                                                                                                                                                                  |
+| **`disabledDatesTextStyle`**         | `TextStyle`           | Optional. Text styling for disabled dates.                                                                                                                                                                                                                                                                                                               |
+| **`selectedStartDate`**              | `Date`                | Optional. Specifies a selected Start Date.                                                                                                                                                                                                                                                                                                               |
+| **`selectedEndDate`**                | `Date`                | Optional. Specifies a selected End Date.                                                                                                                                                                                                                                                                                                                 |
+| **`minRangeDuration`**               | `Number or Array`     | Optional. Specifies a minimum range duration when using allowRangeSelection. Can either pass a number to be used for all dates or an Array of objects if the minimum range duration depends on the date `{date: parsable date, minDuration: Number}`                                                                                                     |
+| **`maxRangeDuration`**               | `Number or Array`     | Optional. Specifies a maximum range duration when using allowRangeSelection. Can either pass a number to be used for all dates or an Array of objects if the maximum range duration depends on the date `{date: parsable date, maxDuration: Number}`                                                                                                     |
+| **`todayBackgroundColor`**           | `String`              | Optional. Background color for today. Default is `#cccccc`                                                                                                                                                                                                                                                                                               |
+| **`todayTextStyle`**                 | `TextStyle`           | Optional. Text styling for today.                                                                                                                                                                                                                                                                                                                        |
+| **`textStyle`**                      | `TextStyle`           | Optional. Style overall text. Change fontFamily, color, etc.                                                                                                                                                                                                                                                                                             |
+| **`customDatesStyles`**              | `Array` or `Func`     | Optional. Style individual date(s). Supports an array of objects `{date: parseable date, containerStyle: ViewStyle, style: ViewStyle, textStyle: TextStyle, allowDisabled: Boolean}`, or a callback which receives a date param and returns `{containerStyle: ViewStyle, style: ViewStyle, textStyle: TextStyle, allowDisabled: Boolean}` for that date. |
+| **`customDayHeaderStyles`**          | `Func`                | Optional. Style day of week header (Monday - Sunday). Callback that receives ISO `{dayOfWeek, month, year}` and should return `{style: ViewStyle, textStyle: TextStyle}`                                                                                                                                                                                 |
+| **`scaleFactor`**                    | `Number`              | Optional. Default (375) scales to window width                                                                                                                                                                                                                                                                                                           |
+| **`minDate`**                        | `Date`                | Optional. Specifies minimum date to be selected                                                                                                                                                                                                                                                                                                          |
+| **`maxDate`**                        | `Date`                | Optional. Specifies maximum date to be selected                                                                                                                                                                                                                                                                                                          |
+| **`initialDate`**                    | `Date`                | Optional. Date that calendar opens to. Defaults to today.                                                                                                                                                                                                                                                                                                |
+| **`width`**                          | `Number`              | Optional. Width of CalendarPicker's container. Defaults to Dimensions width.                                                                                                                                                                                                                                                                             |
+| **`height`**                         | `Number`              | Optional. Height of CalendarPicker's container. Defaults to Dimensions height.                                                                                                                                                                                                                                                                           |
+| **`scrollable`**                     | `Boolean`             | Optional. Months are scrollable if true. Default is `false`                                                                                                                                                                                                                                                                                              |
+| **`horizontal`**                     | `Boolean`             | Optional. Scroll axis when `scrollable` set. Default is `true`                                                                                                                                                                                                                                                                                           |
+| **`enableDateChange`**               | `Boolean`             | Optional. Whether to enable pressing on day. Default is `true`                                                                                                                                                                                                                                                                                           |
+| **`restrictMonthNavigation`**        | `Boolean`             | Optional. Whether to disable Previous month button if it is before minDate or Next month button if it is after MaxDate. Default is `false`                                                                                                                                                                                                               |
+| **`onDateChange`**                   | `Function`            | Optional. Callback when a date is selected. Returns `date` as first param; `START_DATE` or `END_DATE` as second param.                                                                                                                                                                                                                                   |
+| **`onMonthChange`**                  | `Function`            | Optional. Callback when Previous / Next month is pressed. Returns `date` as first parameter.                                                                                                                                                                                                                                                             |
+| **`dayShape`**                       | `String`              | Optional. Shape of the Day component. Default is `circle`. Available options are `circle` and `square`.                                                                                                                                                                                                                                                  |
+| **`headingLevel`**                   | `Number`              | Optional. Sets the aria-level for the calendar title heading when on Web. Default is `1`.                                                                                                                                                                                                                                                                |
+| **`selectMonthTitle`**               | `String`              | Optional. Title of month selector view. Default is "Select Month in " + {year}.                                                                                                                                                                                                                                                                          |
+| **`selectYearTitle`**                | `String`              | Optional. Title of year selector view. Default is "Select Year".                                                                                                                                                                                                                                                                                         |
+| **`dayLabelsWrapper`**               | `ViewStyle`           | Optional. Style for weekdays wrapper. E.g If you want to remove top and bottom divider line.                                                                                                                                                                                                                                                             |
+| **`enableSwipe`**                    | `Deprecated`          | Use `scrollable`.                                                                                                                                                                                                                                                                                                                                        |
+| **`swipeConfig`**                    | `Deprecated`          | Use `scrollable`.                                                                                                                                                                                                                                                                                                                                        |
+| **`onSwipe`**                        | `Deprecated`          | Use `onMonthChange`.                                                                                                                                                                                                                                                                                                                                     |
+| **`dayOfWeekStyles`**                | `Deprecated`          | Use `customDatesStyles` & `customDayHeaderStyles` callbacks to style individual dates, days of week, and/or header.                                                                                                                                                                                                                                      |
+| **`customDatesStylesPriority`**      | `Deprecated`          | Use `customDatesStyles` & `customDayHeaderStyles` callbacks to style individual dates, days of week, and/or header.                                                                                                                                                                                                                                      |
+| **`monthYearHeaderWrapperStyle`**    | `ViewStyle`           | Optional. Style for header MonthYear title wrapper. E.g If you want to change the order of year and month.                                                                                                                                                                                                                                               |
+| **`headerWrapperStyle`**             | `ViewStyle`           | Optional. Style for entire header controls wrapper. This contains the previous / next controls plus month & year.                                                                                                                                                                                                                                        |
+| **`monthTitleStyle`**                | `TextStyle`           | Optional. Text styling for header's month text.                                                                                                                                                                                                                                                                                                          |
+| **`yearTitleStyle`**                 | `TextStyle`           | Optional. Text styling for header's year text.                                                                                                                                                                                                                                                                                                           |
+| **`initialView`**                    | `String`              | Optional. The view that the calendar opens to. Default is `days`. Available options are `years`, `months`, and `days`.                                                                                                                                                                                                                                   |
 
 # Styles
+
 Some styles will overwrite some won't. For instance:
+
 - If you provide textStyle with fontFamily and color, out of ranges dates will not apply your color, just fontFamily.
 
 Order of precedence:
@@ -152,15 +147,13 @@ Order of precedence:
 # More Examples
 
 ### Start from Monday, allowRangeSelection, Min and Max Dates and Styles Changes Example
+
 ![alt tag](https://user-images.githubusercontent.com/6295083/82028654-8f625d00-965b-11ea-8076-45ae609be296.gif)
+
 ```js
-import React, { Component } from 'react';
-import {
-  StyleSheet,
-  Text,
-  View
-} from 'react-native';
-import CalendarPicker from 'react-native-calendar-picker';
+import React, { Component } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import CalendarPicker from "react-native-calendar-picker";
 
 export default class App extends Component {
   constructor(props) {
@@ -173,7 +166,7 @@ export default class App extends Component {
   }
 
   onDateChange(date, type) {
-    if (type === 'END_DATE') {
+    if (type === "END_DATE") {
       this.setState({
         selectedEndDate: date,
       });
@@ -189,8 +182,8 @@ export default class App extends Component {
     const { selectedStartDate, selectedEndDate } = this.state;
     const minDate = new Date(); // Today
     const maxDate = new Date(2017, 6, 3);
-    const startDate  =  selectedStartDate ? selectedStartDate.toString() : '';
-    const endDate = selectedEndDate ? selectedEndDate.toString() : '';
+    const startDate = selectedStartDate ? selectedStartDate.toString() : "";
+    const endDate = selectedEndDate ? selectedEndDate.toString() : "";
 
     return (
       <View style={styles.container}>
@@ -206,8 +199,8 @@ export default class App extends Component {
         />
 
         <View>
-          <Text>SELECTED START DATE:{ startDate }</Text>
-          <Text>SELECTED END DATE:{ endDate }</Text>
+          <Text>SELECTED START DATE:{startDate}</Text>
+          <Text>SELECTED END DATE:{endDate}</Text>
         </View>
       </View>
     );
@@ -217,7 +210,7 @@ export default class App extends Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#FFFFFF',
+    backgroundColor: "#FFFFFF",
     marginTop: 100,
   },
 });
@@ -228,13 +221,9 @@ const styles = StyleSheet.create({
 ![alt tag](https://user-images.githubusercontent.com/6295083/82028709-9c7f4c00-965b-11ea-9705-790ce38929c0.gif)
 
 ```js
-import React, { Component } from 'react';
-import {
-  StyleSheet,
-  Text,
-  View
-} from 'react-native';
-import CalendarPicker from 'react-native-calendar-picker';
+import React, { Component } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import CalendarPicker from "react-native-calendar-picker";
 
 export default class App extends Component {
   constructor(props) {
@@ -247,7 +236,7 @@ export default class App extends Component {
   }
 
   onDateChange(date, type) {
-    if (type === 'END_DATE') {
+    if (type === "END_DATE") {
       this.setState({
         selectedEndDate: date,
       });
@@ -263,8 +252,8 @@ export default class App extends Component {
     const { selectedStartDate, selectedEndDate } = this.state;
     const minDate = new Date(); // Today
     const maxDate = new Date(2017, 6, 3);
-    const startDate  =  selectedStartDate ? selectedStartDate.toString() : '';
-    const endDate = selectedEndDate ? selectedEndDate.toString() : '';
+    const startDate = selectedStartDate ? selectedStartDate.toString() : "";
+    const endDate = selectedEndDate ? selectedEndDate.toString() : "";
 
     return (
       <View style={styles.container}>
@@ -273,8 +262,21 @@ export default class App extends Component {
           allowRangeSelection={true}
           minDate={minDate}
           maxDate={maxDate}
-          weekdays={['Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sab', 'Dom']}
-          months={['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro']}
+          weekdays={["Seg", "Ter", "Qua", "Qui", "Sex", "Sab", "Dom"]}
+          months={[
+            "Janeiro",
+            "Fevereiro",
+            "Março",
+            "Abril",
+            "Maio",
+            "Junho",
+            "Julho",
+            "Agosto",
+            "Setembro",
+            "Outubro",
+            "Novembro",
+            "Dezembro",
+          ]}
           previousTitle="Anterior"
           nextTitle="Próximo"
           todayBackgroundColor="#e6ffe6"
@@ -282,15 +284,15 @@ export default class App extends Component {
           selectedDayTextColor="#000000"
           scaleFactor={375}
           textStyle={{
-            fontFamily: 'Cochin',
-            color: '#000000',
+            fontFamily: "Cochin",
+            color: "#000000",
           }}
           onDateChange={this.onDateChange}
         />
 
         <View>
-          <Text>SELECTED START DATE:{ startDate }</Text>
-          <Text>SELECTED END DATE:{ endDate }</Text>
+          <Text>SELECTED START DATE:{startDate}</Text>
+          <Text>SELECTED END DATE:{endDate}</Text>
         </View>
       </View>
     );
@@ -300,12 +302,11 @@ export default class App extends Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#FFFFFF',
+    backgroundColor: "#FFFFFF",
     marginTop: 100,
   },
 });
 ```
-
 
 ### Custom styling individual dates
 
@@ -313,7 +314,7 @@ const styles = StyleSheet.create({
 
 ```js
 
-let today = moment();
+let today = new Date();
 let day = today.clone().startOf('month');
 let customDatesStyles = [];
 while(day.add(1, 'day').isSame(today, 'month')) {
@@ -391,20 +392,20 @@ const customDatesStylesCallback = date => {
 
 These internal methods may be accessed through a ref to the CalendarPicker.
 
-| Name | Params | Description |
-:------------ |:---------------| :-----|
-| **`handleOnPressDay`** | `{year, month, day} (Integers)` | Programmatically select date. `year`, `month` and `day` are numbers. `day` is the day of the current month. Moment example for today's day of month: `moment().date()` |
-| **`handleOnPressNext`** |  | Programmatically advance to next month. |
-| **`handleOnPressPrevious`** |  | Programmatically advance to previous month. |
-| **`resetSelections`** |  | Clear date selections. Useful for resetting date range selection when user has picked a start date but not an end date. |
+| Name                        | Params                          | Description                                                                                                                                                                  |
+| :-------------------------- | :------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`handleOnPressDay`**      | `{year, month, day} (Integers)` | Programmatically select date. `year`, `month` and `day` are numbers. `day` is the day of the current month. date-fns example for today's day of month: `getDate(new Date())` |
+| **`handleOnPressNext`**     |                                 | Programmatically advance to next month.                                                                                                                                      |
+| **`handleOnPressPrevious`** |                                 | Programmatically advance to previous month.                                                                                                                                  |
+| **`resetSelections`**       |                                 | Clear date selections. Useful for resetting date range selection when user has picked a start date but not an end date.                                                      |
 
 ## TypeScript
 
 Definitions are available at https://www.npmjs.com/package/@types/react-native-calendar-picker courtesy of [automatensalat](https://github.com/automatensalat).
+
 ```
 npm install --save @types/react-native-calendar-picker
 ```
-
 
 # Suggestions?
 
@@ -423,10 +424,10 @@ I would like to call out some contributors who have been helping with this proje
 - [adamkrell](https://github.com/adamkrell)
 - [joshuapinter](https://github.com/joshuapinter)
 
-
 # Sample Application
 
 The sample app is an Expo project created with `create-react-native-app`.
+
 ```sh
 cd example
 npm run cp
@@ -436,4 +437,4 @@ npm start
 
 ## Development
 
-The source files are copied from the project root directory into `example` using `npm run cp`.  If a source file is modified, it must be copied over again with `npm run cp`.
+The source files are copied from the project root directory into `example` using `npm run cp`. If a source file is modified, it must be copied over again with `npm run cp`.

--- a/example/example/App.js
+++ b/example/example/App.js
@@ -7,32 +7,32 @@ import {
   TextInput,
   Switch,
 } from 'react-native';
-import moment from 'moment';
+import { addDays, format, subDays } from 'date-fns';
 import CalendarPicker from './CalendarPicker';
 
 export default class App extends Component {
   constructor(props) {
     super(props);
 
-    let minDate = moment().subtract(15, 'day');
-    let day = minDate.clone();
+    let minDate = subDays(new Date(), 15);
+    let day = minDate;
     let customDatesStyles = [];
     for (let i = 0; i < 30; i++) {
       customDatesStyles.push({
-        date: day.clone(),
+        date: day,
         // Random colors
-        style: {backgroundColor: '#'+('#00000'+(Math.random()*(64<<22)|32768).toString(16)).slice(-6)},
-        textStyle: {color: 'black'}, // sets the font color
+        style: { backgroundColor: '#' + ('#00000' + (Math.random() * (64 << 22) | 32768).toString(16)).slice(-6) },
+        textStyle: { color: 'black' }, // sets the font color
         containerStyle: [], // extra styling for day container
       });
-      day.add(1, 'day');
+      day = addDays(day, 1);
     }
 
     this.state = {
       customDatesStyles,
       enableRangeSelect: false,
       minDate,
-      maxDate: moment().add(90, 'day'),
+      maxDate: addDays(new Date(), 90),
       minRangeDuration: "1",
       maxRangeDuration: "5",
       selectedStartDate: null,
@@ -90,8 +90,8 @@ export default class App extends Component {
     });
   }
 
-  customDayHeaderStylesCallback({dayOfWeek, month, year}) {
-    switch(dayOfWeek) {
+  customDayHeaderStylesCallback({ dayOfWeek, month, year }) {
+    switch (dayOfWeek) {
       case 4: // Thursday
         return {
           style: {
@@ -117,8 +117,8 @@ export default class App extends Component {
       selectedStartDate,
       selectedEndDate,
     } = this.state;
-    const formattedStartDate = selectedStartDate ? selectedStartDate.format('YYYY-MM-DD') : '';
-    const formattedEndDate = selectedEndDate ? selectedEndDate.format('YYYY-MM-DD') : '';
+    const formattedStartDate = selectedStartDate ? format(selectedStartDate, 'yyyy-MM-dd') : '';
+    const formattedEndDate = selectedEndDate ? format(selectedEndDate, 'yyyy-MM-dd') : '';
 
     return (
       <View style={styles.container}>
@@ -140,14 +140,14 @@ export default class App extends Component {
         />
 
         <View style={styles.topSpacing}>
-          <Text style={styles.text}>Selected (Start) date:  { formattedStartDate }</Text>
-          { !!formattedEndDate &&
-            <Text style={styles.text}>Selected End date:  { formattedEndDate }</Text>
+          <Text style={styles.text}>Selected (Start) date:  {formattedStartDate}</Text>
+          {!!formattedEndDate &&
+            <Text style={styles.text}>Selected End date:  {formattedEndDate}</Text>
           }
         </View>
 
         <View style={styles.topSpacing}>
-          <Button onPress={this.clear} title="Clear Selection"/>
+          <Button onPress={this.clear} title="Clear Selection" />
         </View>
 
         <View style={styles.topSpacing}>
@@ -161,7 +161,7 @@ export default class App extends Component {
           value={enableRangeSelect}
         />
 
-        { enableRangeSelect &&
+        {enableRangeSelect &&
           <View>
             <Text style={styles.text}>minRangeDuration:</Text>
             <TextInput
@@ -193,7 +193,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   topSpacing: {
-    marginTop:20
+    marginTop: 20
   },
   text: {
     fontSize: 24,

--- a/example/example/app.json
+++ b/example/example/app.json
@@ -3,7 +3,6 @@
     "name": "CalendarPicker example",
     "slug": "example",
     "privacy": "public",
-    "sdkVersion": "36.0.0",
     "platforms": [
       "ios",
       "android",

--- a/example/example/package.json
+++ b/example/example/package.json
@@ -2,7 +2,7 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
-    "cp": "cpx \"../CalendarPicker/**\" CalendarPicker -u",
+    "cp": "cpx \"../../CalendarPicker/**\" CalendarPicker -u",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
@@ -15,18 +15,18 @@
   },
   "dependencies": {
     "date-fns": "^3.1.0",
-    "expo": "~36.0.0",
-    "react": "~16.9.0",
-    "react-dom": "~16.9.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-36.0.0.tar.gz",
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.72.5",
     "react-native-calendar-picker": "file:../",
-    "react-native-web": "~0.11.7",
-    "recyclerlistview": "^3.0.0"
+    "react-native-web": "~0.19.6",
+    "recyclerlistview": "~3.0.0"
   },
   "devDependencies": {
     "@deboxsoft/cpx": "^1.5.0",
-    "jest": "^25.1.0",
-    "react-test-renderer": "~16.12.0"
+    "jest": "^29.2.1",
+    "react-test-renderer": "~18.2.0"
   },
   "private": true
 }

--- a/example/example/package.json
+++ b/example/example/package.json
@@ -14,6 +14,7 @@
     "preset": "react-native"
   },
   "dependencies": {
+    "date-fns": "^3.1.0",
     "expo": "~36.0.0",
     "react": "~16.9.0",
     "react-dom": "~16.9.0",
@@ -25,7 +26,6 @@
   "devDependencies": {
     "@deboxsoft/cpx": "^1.5.0",
     "jest": "^25.1.0",
-    "moment": "*",
     "react-test-renderer": "~16.12.0"
   },
   "private": true

--- a/example/example_typescript/package.json
+++ b/example/example_typescript/package.json
@@ -24,9 +24,9 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "date-fns": "^3.1.0",
     "expo": "~42.0.0",
     "expo-status-bar": "~1.0.4",
-    "moment": "^2.29.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-42.0.0.tar.gz",

--- a/example/example_typescript/package.json
+++ b/example/example_typescript/package.json
@@ -38,7 +38,7 @@
     "@types/react": "~16.9.35",
     "@types/react-native": "~0.63.2",
     "typescript": "~4.0.0",
-    "@types/react-native-calendar-picker": "^7.0.1",
+    "@types/react-native-calendar-picker": "^7.0.1"
   },
   "private": false
 }

--- a/example/example_typescript/src/components/CalendarView/index.js
+++ b/example/example_typescript/src/components/CalendarView/index.js
@@ -22,14 +22,14 @@ export function CalendarView(props) {
     function onDateChange(date, type) {
         if (type === 'END_DATE') {
             if (date) {
-                setEndDate(date.toDate())
+                setEndDate(date)
                 return
             }
             setEndDate(null)
         }
         else {
-            setEndDate(date.toDate())
-            setStartDate(date.toDate())
+            setEndDate(date)
+            setStartDate(date)
         }
     }
 

--- a/example/example_typescript/src/components/CalendarView/index.tsx
+++ b/example/example_typescript/src/components/CalendarView/index.tsx
@@ -6,7 +6,6 @@ import {
     Text
 } from 'react-native';
 import CalendarPicker from 'react-native-calendar-picker';
-import { Moment } from "moment";
 
 import { week, monthFull } from "./config"
 import { colors } from "../../global/colors";
@@ -30,17 +29,17 @@ export function CalendarView(props: CalendarViewProps) {
         scroll = false
     } = props
 
-    function onDateChange(date: Moment, type: 'START_DATE' | 'END_DATE') {
+    function onDateChange(date: Date, type: 'START_DATE' | 'END_DATE') {
         if (type === 'END_DATE') {
             if (date) {
-                setEndDate(date.toDate())
+                setEndDate(date)
                 return
             }
             setEndDate(null)
         }
         else {
-            setEndDate(date.toDate())
-            setStartDate(date.toDate())
+            setEndDate(date)
+            setStartDate(date)
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "react-native-calendar-picker",
-  "version": "7.1.5",
+  "version": "8.0.0",
   "description": "Calendar Picker Component for React Native",
   "engines": {
     "node": ">=4.0.0"
   },
   "peerDependencies": {
-    "moment": ">=2.0.0",
     "react": "*",
     "react-native": "*"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-calendar-picker",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "description": "Calendar Picker Component for React Native",
   "engines": {
     "node": ">=4.0.0"
@@ -48,6 +48,7 @@
   ],
   "directories": {},
   "dependencies": {
+    "date-fns": "^3.1.0",
     "node-git-hooks": "^1.0.1",
     "prop-types": "^15.6.0",
     "recyclerlistview": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
+    "date-fns": "^3.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-react": "^7.19.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "react-native-calendar-picker",
-  "version": "8.0.0",
+  "version": "8.0.0-alpha",
   "description": "Calendar Picker Component for React Native",
   "engines": {
     "node": ">=4.0.0"
   },
   "peerDependencies": {
+    "date-fns": "*",
     "react": "*",
     "react-native": "*"
   },
@@ -47,7 +48,6 @@
   ],
   "directories": {},
   "dependencies": {
-    "date-fns": "^3.1.0",
     "node-git-hooks": "^1.0.1",
     "prop-types": "^15.6.0",
     "recyclerlistview": "^3.0.0"


### PR DESCRIPTION
I think there are good reasons to replace [moment.js](https://github.com/moment/moment) with [date-fns](https://date-fns.org/).
A way lighter, more performant, more popular, library, without the mutability quirks of moment.

This PR removes all imports of, references to, and moment specific methods from the code base, and replaces it with equivalent utilities from `date-fns` - which is added as a dependency.

It should be fully backwards compatible with earlier versions.

I've updated the version to 8.0.0 and reflected the changes in the README file.

[Issue #360](https://github.com/stephy/CalendarPicker/issues/360)