### PR TITLE
Individual imports of date-fns + 8.0.0 release

### DIFF
--- a/CalendarPicker/Day.js
+++ b/CalendarPicker/Day.js
@@ -5,7 +5,13 @@ import {
   TouchableOpacity
 } from 'react-native';
 import PropTypes from 'prop-types';
-import { differenceInDays, isAfter, isBefore, isSameDay, isWithinInterval, startOfDay } from 'date-fns';
+
+import { differenceInDays } from 'date-fns/differenceInDays';
+import { isAfter } from 'date-fns/isAfter';
+import { isBefore } from 'date-fns/isBefore';
+import { isSameDay } from 'date-fns/isSameDay';
+import { isWithinInterval } from 'date-fns/isWithinInterval';
+import { startOfDay } from 'date-fns/startOfDay';
 
 export default function Day(props) {
   const {

--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -5,7 +5,8 @@ import { stylePropType } from './localPropTypes';
 import Day from './Day';
 import EmptyDay from './EmptyDay';
 import { Utils } from './Utils';
-import { getISODay } from 'date-fns';
+
+import { getISODay } from 'date-fns/getISODay';
 
 export default class DaysGridView extends Component {
   constructor(props) {

--- a/CalendarPicker/Month.js
+++ b/CalendarPicker/Month.js
@@ -6,7 +6,9 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { Utils } from './Utils';
-import { getMonth, getYear } from 'date-fns';
+
+import { getMonth } from 'date-fns/getMonth';
+import { getYear } from 'date-fns/getYear';
 
 export default function Month(props) {
   const {

--- a/CalendarPicker/Scroller.js
+++ b/CalendarPicker/Scroller.js
@@ -9,7 +9,13 @@ import React, { Component } from 'react';
 import { View, Platform } from 'react-native';
 import PropTypes from 'prop-types';
 import { RecyclerListView, DataProvider, LayoutProvider } from 'recyclerlistview';
-import { addMonths, endOfMonth, isAfter, isBefore, isSameMonth, startOfMonth } from 'date-fns';
+
+import { addMonths } from 'date-fns/addMonths';
+import { endOfMonth } from 'date-fns/endOfMonth';
+import { isAfter } from 'date-fns/isAfter';
+import { isBefore } from 'date-fns/isBefore';
+import { isSameMonth } from 'date-fns/isSameMonth';
+import { startOfMonth } from 'date-fns/startOfMonth';
 
 export default class CalendarScroller extends Component {
   static propTypes = {

--- a/CalendarPicker/Utils.js
+++ b/CalendarPicker/Utils.js
@@ -5,7 +5,10 @@
  * Licensed under the terms of the MIT license. See LICENSE file in the project root for terms.
  */
 
-import { getMonth, getYear, isSameDay, isSameMonth } from "date-fns";
+import { getMonth } from 'date-fns/getMonth';
+import { getYear } from 'date-fns/getYear';
+import { isSameDay } from 'date-fns/isSameDay';
+import { isSameMonth } from 'date-fns/isSameMonth';
 
 export const Utils = {
   START_DATE: 'START_DATE',

--- a/CalendarPicker/Year.js
+++ b/CalendarPicker/Year.js
@@ -5,7 +5,12 @@ import {
   TouchableOpacity
 } from 'react-native';
 import PropTypes from 'prop-types';
-import { getMonth, getYear, isAfter, isBefore, startOfMonth } from 'date-fns';
+
+import { getMonth } from 'date-fns/getMonth';
+import { getYear } from 'date-fns/getYear';
+import { isAfter } from 'date-fns/isAfter';
+import { isBefore } from 'date-fns/isBefore';
+import { startOfMonth } from 'date-fns/startOfMonth';
 
 export default function Year(props) {
   const {

--- a/CalendarPicker/YearsHeader.js
+++ b/CalendarPicker/YearsHeader.js
@@ -7,7 +7,8 @@ import {
 import PropTypes from 'prop-types';
 import { stylePropType } from './localPropTypes';
 import Controls from './Controls';
-import { getYear } from 'date-fns';
+
+import { getYear } from 'date-fns/getYear';
 
 export default function YearsHeader(props) {
   const {

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -8,7 +8,16 @@ import DaysGridView from './DaysGridView';
 import MonthSelector from './MonthSelector';
 import YearSelector from './YearSelector';
 import Scroller from './Scroller';
-import { addMonths, getMonth, getYear, isAfter, isBefore, isSameDay, isSameMonth, startOfMonth, subMonths } from 'date-fns';
+
+import { addMonths } from 'date-fns/addMonths';
+import { getMonth } from 'date-fns/getMonth';
+import { getYear } from 'date-fns/getYear';
+import { isAfter } from 'date-fns/isAfter';
+import { isBefore } from 'date-fns/isBefore';
+import { isSameDay } from 'date-fns/isSameDay';
+import { isSameMonth } from 'date-fns/isSameMonth';
+import { startOfMonth } from 'date-fns/startOfMonth';
+import { subMonths } from 'date-fns/subMonths';
 
 export default class CalendarPicker extends Component {
   constructor(props) {

--- a/example/example/App.js
+++ b/example/example/App.js
@@ -7,7 +7,11 @@ import {
   TextInput,
   Switch,
 } from 'react-native';
-import { addDays, format, subDays } from 'date-fns';
+
+import { addDays } from 'date-fns/addDays';
+import { format } from 'date-fns/format';
+import { subDays } from 'date-fns/subDays';
+
 import CalendarPicker from './CalendarPicker';
 
 export default class App extends Component {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-calendar-picker",
-  "version": "8.0.0-alpha",
+  "version": "8.0.0",
   "description": "Calendar Picker Component for React Native",
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
Switched to individual import of date-fns to allow for tree shaking.

Updated version to 8.0.0.

I've been using the alpha version in my own projects with no issues, and there seems to have been some traction of the alpha version with no complaints yet - so I think we're ready to release it.

<img width="682" alt="Screenshot 2024-01-12 at 17 31 23" src="https://github.com/stephy/CalendarPicker/assets/6737260/7215a059-4fe6-4a52-bf7e-575c3a209cb1">
