### PR TITLE
Fix months shifting to use proper date-fns methods and backwards range date selection

### DIFF
--- a/CalendarPicker/Scroller.js
+++ b/CalendarPicker/Scroller.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import { RecyclerListView, DataProvider, LayoutProvider } from 'recyclerlistview';
 
 import { addMonths } from 'date-fns/addMonths';
+import { subMonths } from 'date-fns/subMonths';
 import { endOfMonth } from 'date-fns/endOfMonth';
 import { isAfter } from 'date-fns/isAfter';
 import { isBefore } from 'date-fns/isBefore';
@@ -152,8 +153,8 @@ export default class CalendarScroller extends Component {
   }
 
   shiftMonths = (currentMonth, offset) => {
-    const prevVisMonth = currentMonth.clone();
-    const newStartMonth = prevVisMonth.clone().subtract(Math.floor(offset), 'months');
+    const prevVisMonth = new Date(currentMonth);
+    const newStartMonth = subMonths(new Date(prevVisMonth), Math.floor(offset));
     this.updateMonths(prevVisMonth, newStartMonth);
   }
 

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -256,7 +256,7 @@ export default class CalendarPicker extends Component {
     const date = new Date(year, month, day, 12);
 
     if (allowRangeSelection && prevSelectedStartDate && !prevSelectedEndDate) {
-      if (!isAfter(date, prevSelectedEndDate)) {
+      if (isAfter(date, prevSelectedStartDate)) {
         const selectedStartDate = prevSelectedStartDate;
         const selectedEndDate = date;
         this.setState({


### PR DESCRIPTION
- It was using some weird non-existent date functions, probably left over from moment migration, fixed it to use the proper date-fns ones;
- Also it wasn't working properly the backwards range date selection due to a logic error on date comparison to the previously selected date (that was comparing to the wrong variable);
