### PR TITLE
fix: empty 1st row in Days Calendar

### DIFF
--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -45,7 +45,7 @@ export default class DaysGridView extends Component {
       const firstWeekDay = getISODay(firstDayOfMonth);
 
       // Determine starting index based on first day of week prop.
-      const startIndex = (firstDay > 0) ? (firstWeekDay + Utils.FIRST_DAY_OFFSETS[firstDay]) % 7 : firstWeekDay % 7;
+      const startIndex = ((firstDay > 0) ? (firstWeekDay + Utils.FIRST_DAY_OFFSETS[firstDay]) : firstWeekDay) % 7;
 
       return {
         maxWeekRows: 6,

--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -45,7 +45,7 @@ export default class DaysGridView extends Component {
       const firstWeekDay = getISODay(firstDayOfMonth);
 
       // Determine starting index based on first day of week prop.
-      const startIndex = (firstDay > 0) ? (firstWeekDay + Utils.FIRST_DAY_OFFSETS[firstDay]) % 7 : firstWeekDay;
+      const startIndex = (firstDay > 0) ? (firstWeekDay + Utils.FIRST_DAY_OFFSETS[firstDay]) % 7 : firstWeekDay % 7;
 
       return {
         maxWeekRows: 6,


### PR DESCRIPTION
Fixes #378 

This issue was happening when firstWeekDay of month is 7 and firstDay prop value is 0 which make startIndex 7 but as per logic startIndex should be from 0 to 6, so this leads render of an empty row as first row.

Fix: Correct value of startIndex for this case should be 0. Hence added % 7 to restrict startIndex to be from 0 to  6.