### PR TITLE
Single date select re-render

### DIFF
--- a/CalendarPicker/DaysGridView.js
+++ b/CalendarPicker/DaysGridView.js
@@ -68,7 +68,15 @@ export default class DaysGridView extends Component {
   componentDidUpdate(prevProps) {
     // Optimize re-renders by checking props, with special handling for selected dates.
     // Shallow compare prop changes, excluding selected dates.
-    const propDiffs = Utils.shallowDiff(this.props, prevProps, ['selectedStartDate', 'selectedEndDate']);
+    let excludedProps = []
+
+    // Avoid unecessary re-render when selecting date range
+    if (this.props.selectedEndDate) {
+      excludedProps = ['selectedStartDate', 'selectedEndDate']
+    }
+
+    const propDiffs = Utils.shallowDiff(this.props, prevProps, excludedProps);
+
     if (propDiffs.length) {
       // Recreate days
       const monthSettings = this.initMonthSettings(this.props);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-calendar-picker",
-  "version": "8.0.2",
+  "version": "8.0.4",
   "description": "Calendar Picker Component for React Native",
   "engines": {
     "node": ">=4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-calendar-picker",
-  "version": "8.0.4",
+  "version": "8.0.3",
   "description": "Calendar Picker Component for React Native",
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
When selecting a single date (not a date range), the Day component would not re-render when the start date was changed.
[Issue 376](https://github.com/stephy/CalendarPicker/issues/376)

This was due to an optimization avoiding this unecessary re-render when changing a selected date range.


https://github.com/stephy/CalendarPicker/assets/6737260/96794f17-7900-4eaf-9e57-ce824cd69ecd

