### PR TITLE
[#283] Invoking handleOnPressDay updates the visible month to the given date

### DIFF
--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -288,6 +288,8 @@ export default class CalendarPicker extends Component {
       this.setState({
         selectedStartDate,
         selectedEndDate,
+        currentMonth: month,
+        currentYear: year,
         renderMonthParams: this.createMonthProps({ ...this.state, selectedStartDate, selectedEndDate }),
       }, () => {
         // Sync start date with parent *after* state update.

--- a/CalendarPicker/index.js
+++ b/CalendarPicker/index.js
@@ -290,7 +290,13 @@ export default class CalendarPicker extends Component {
         selectedEndDate,
         currentMonth: month,
         currentYear: year,
-        renderMonthParams: this.createMonthProps({ ...this.state, selectedStartDate, selectedEndDate }),
+        renderMonthParams: this.createMonthProps({ 
+          ...this.state, 
+          currentMonth: month,
+          currentYear: year,
+          selectedStartDate, 
+          selectedEndDate 
+        }),
       }, () => {
         // Sync start date with parent *after* state update.
         onDateChange(this.state.selectedStartDate, Utils.START_DATE);

--- a/example/example/App.js
+++ b/example/example/App.js
@@ -46,6 +46,9 @@ export default class App extends Component {
     this.toggleEnableRange = this.toggleEnableRange.bind(this);
     this.onMinRangeDuration = this.onMinRangeDuration.bind(this);
     this.onMaxRangeDuration = this.onMaxRangeDuration.bind(this);
+    this.onSelectToday = this.onSelectToday.bind(this);
+    
+    this.calendarRef = React.createRef(null);
   }
 
   onDateChange(date, type) {
@@ -94,6 +97,11 @@ export default class App extends Component {
     });
   }
 
+  onSelectToday() {
+    const today = new Date()
+    this.calendarRef.current.handleOnPressDay({ day: today.getDate(), month: today.getMonth(), year: today.getFullYear() })
+  }
+
   customDayHeaderStylesCallback({ dayOfWeek, month, year }) {
     switch (dayOfWeek) {
       case 4: // Thursday
@@ -127,6 +135,7 @@ export default class App extends Component {
     return (
       <View style={styles.container}>
         <CalendarPicker
+          ref={this.calendarRef}
           scrollable
           selectedStartDate={selectedStartDate}
           selectedEndDate={selectedEndDate}
@@ -152,6 +161,10 @@ export default class App extends Component {
 
         <View style={styles.topSpacing}>
           <Button onPress={this.clear} title="Clear Selection" />
+        </View>
+
+        <View style={styles.topSpacing}>
+          <Button onPress={this.onSelectToday} title="Select today" />
         </View>
 
         <View style={styles.topSpacing}>


### PR DESCRIPTION
# Description
Addresses [this issue](https://github.com/stephy/CalendarPicker/issues/283) where invoking the `handleOnPressDay(date)` method doesn't update the visible month to the one that contains `date`.

# Changes
- updated `handleOnPressDay` method to set `currentMonth/Year`
- updated example app to demonstrate use case

# Limitations
- I'm not sure if we **always** want the behaviour where invoking `handleOnPressDay` updates the visible month. If not, we could consider adding a boolean argument to `handleOnPressDay` for whether the visible month should be updated
- there's another code path in `handleOnPressDay` for when range selection is enabled that I didn't address. I'm not as familiar with this feature so I didn't want to impose a product decision here
- my fix doesn't seem to work when `scrollable` is set to `true`

# Demo
## Before

https://github.com/stephy/CalendarPicker/assets/144704010/ec26f3ed-694f-4092-bc94-12a172db822f

## After

https://github.com/stephy/CalendarPicker/assets/144704010/645e3594-7410-4c5a-bc5a-7e673ec3de3c


