### PR TITLE
#383  support for defaultprops

### DIFF
--- a/CalendarPicker/Day.js
+++ b/CalendarPicker/Day.js
@@ -19,7 +19,7 @@ export default function Day(props) {
     month,
     year,
     styles,
-    customDatesStyles,
+    customDatesStyles = [],
     onPressDay,
     selectedStartDate,
     selectedEndDate,
@@ -41,7 +41,7 @@ export default function Day(props) {
     disabledDatesTextStyle,
     minRangeDuration,
     maxRangeDuration,
-    enableDateChange
+    enableDateChange,
   } = props;
 
   const thisDay = new Date(year, month, day, 12);
@@ -252,10 +252,6 @@ function getCustomDateStyle({ customDatesStyles, date }) {
   }
   return {};
 }
-
-Day.defaultProps = {
-  customDatesStyles: [],
-};
 
 Day.propTypes = {
   styles: PropTypes.shape({}),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-calendar-picker",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "description": "Calendar Picker Component for React Native",
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
Taking https://github.com/stephy/CalendarPicker/issues/383 and creating a simple PR.
Instead of having default props being defined as class components do, simply use javascript to default to an empty array when destructuring props